### PR TITLE
Upd/1.2.9

### DIFF
--- a/Megrez.Tests/LMDataForTests.cs
+++ b/Megrez.Tests/LMDataForTests.cs
@@ -1,0 +1,197 @@
+﻿// CSharpened by (c) 2022 and onwards The vChewing Project (MIT-NTL License).
+// Rebranded from (c) Lukhnos Liu's C++ library "Gramambular" (MIT License).
+/*
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Megrez.Tests;
+
+public class SimpleLM : LangModelProtocol {
+  private Dictionary<string, List<Unigram>> _database = new();
+  public SimpleLM(string input, bool swapKeyValue = false) {
+    List<string> sStream = new(input.Split('\n'));
+    foreach (string line in sStream) {
+      if (line.Length == 0 || line.FirstOrDefault().CompareTo('#') == 0) continue;
+      List<string> lineStream = new(line.Split(' '));
+      if (lineStream.Count >= 2) {
+        string col0 = lineStream[0];  // 假設其不為 nil
+        string col1 = lineStream[1];  // 假設其不為 nil
+        double col2 = 0;              // 防呆
+        if (lineStream.Count >= 3 && double.TryParse(lineStream[2], out double number)) col2 = number;
+        Unigram u = new(new KeyValuePaired(), 0);
+        if (swapKeyValue)
+          u.KeyValue = new(col1, col0);
+        else
+          u.KeyValue = new(col0, col1);
+        u.Score = col2;
+        if (!_database.ContainsKey(u.KeyValue.Key)) _database.Add(u.KeyValue.Key, new List<Unigram> {});
+        _database[u.KeyValue.Key].Add(u);
+      }
+    }
+  }
+  public List<Bigram> BigramsFor(string precedingKey, string key) { return new(); }
+  public List<Unigram> UnigramsFor(string key) => _database.ContainsKey(key) ? _database[key] : new();
+  public bool HasUnigramsFor(string key) => _database.ContainsKey(key);
+}
+
+public class MockLM : LangModelProtocol {
+  List<Bigram> LangModelProtocol.BigramsFor(string precedingKey, string key) => new();
+
+  bool LangModelProtocol.HasUnigramsFor(string key) => !string.IsNullOrEmpty(key);
+
+  List<Unigram> LangModelProtocol.UnigramsFor(string key) => new() { new(new(key, key), -1) };
+}
+
+public class TestLM : LangModelProtocol {
+  public List<Bigram> BigramsFor(string precedingKey, string key) => new();
+
+  public bool HasUnigramsFor(string key) => key == "foo";
+  public List<Unigram> UnigramsFor(string key) => key == "foo" ? new() { new(new(key, key), -1) } : new();
+}
+
+public class TestDataClass {
+  public static string StrStressData =
+      @"
+yi1 一 -2.08170692
+yi1-yi1 一一 -4.38468400
+
+    ";
+
+  public static string StrEmojiSampleData =
+      @"
+gao1 高 -2.9396
+re4 熱 -3.6024
+gao1re4 高熱 -6.526
+huo3 火 -3.6966
+huo3 🔥 -8
+yan4 焰 -5.4466
+huo3yan4 火焰 -5.6231
+huo3yan4 🔥 -8
+wei2 危 -3.9832
+xian3 險 -3.7810
+wei2xian3 危險 -4.2623
+mi4feng1 蜜蜂 -3.6231
+mi4 蜜 -4.6231
+feng1 蜂 -4.6231
+feng1 🐝 -11
+mi4feng1 🐝 -11
+
+      ";
+
+  public static string StrSampleData =
+      @"
+#
+# 下述詞頻資料取自 libTaBE 資料庫 (http://sourceforge.net/projects/libtabe/)
+# (2002 最終版). 該專案於 1999 年由 Pai-Hsiang Hsiao 發起、以 BSD 授權發行。
+#
+
+ni3 你 -6.000000 // Non-LibTaBE
+zhe4 這 -6.000000 // Non-LibTaBE
+yang4 樣 -6.000000 // Non-LibTaBE
+si1 絲 -9.495858
+si1 思 -9.006414
+si1 私 -99.000000
+si1 斯 -8.091803
+si1 司 -99.000000
+si1 嘶 -13.513987
+si1 撕 -12.259095
+gao1 高 -7.171551
+ke1 顆 -10.574273
+ke1 棵 -11.504072
+ke1 刻 -10.450457
+ke1 科 -7.171052
+ke1 柯 -99.000000
+gao1 膏 -11.928720
+gao1 篙 -13.624335
+gao1 糕 -12.390804
+de5 的 -3.516024
+di2 的 -3.516024
+di4 的 -3.516024
+zhong1 中 -5.809297
+de5 得 -7.427179
+gong1 共 -8.381971
+gong1 供 -8.501463
+ji4 既 -99.000000
+jin1 今 -8.034095
+gong1 紅 -8.858181
+ji4 際 -7.608341
+ji4 季 -99.000000
+jin1 金 -7.290109
+ji4 騎 -10.939895
+zhong1 終 -99.000000
+ji4 記 -99.000000
+ji4 寄 -99.000000
+jin1 斤 -99.000000
+ji4 繼 -9.715317
+ji4 計 -7.926683
+ji4 暨 -8.373022
+zhong1 鐘 -9.877580
+jin1 禁 -10.711079
+gong1 公 -7.877973
+gong1 工 -7.822167
+gong1 攻 -99.000000
+gong1 功 -99.000000
+gong1 宮 -99.000000
+zhong1 鍾 -9.685671
+ji4 繫 -10.425662
+gong1 弓 -99.000000
+gong1 恭 -99.000000
+ji4 劑 -8.888722
+ji4 祭 -10.204425
+jin1 浸 -11.378321
+zhong1 盅 -99.000000
+ji4 忌 -99.000000
+ji4 技 -8.450826
+jin1 筋 -11.074890
+gong1 躬 -99.000000
+ji4 冀 -12.045357
+zhong1 忠 -99.000000
+ji4 妓 -99.000000
+ji4 濟 -9.517568
+ji4 薊 -12.021587
+jin1 巾 -99.000000
+jin1 襟 -12.784206
+nian2 年 -6.086515
+jiang3 講 -9.164384
+jiang3 獎 -8.690941
+jiang3 蔣 -10.127828
+nian2 黏 -11.336864
+nian2 粘 -11.285740
+jiang3 槳 -12.492933
+gong1si1 公司 -6.299461
+ke1ji4 科技 -6.736613
+ji4gong1 濟公 -13.336653
+jiang3jin1 獎金 -10.344678
+nian2zhong1 年終 -11.668947
+nian2zhong1 年中 -11.373044
+gao1ke1ji4 高科技 -9.842421
+zhe4yang4 這樣 -6.000000 // Non-LibTaBE
+ni3zhe4 你這 -9.000000 // Non-LibTaBE
+jiao4 教 -3.676169
+jiao4 較 -3.24869962
+jiao4yu4 教育 -3.32220565
+yu4 育 -3.30192952
+";
+}

--- a/Megrez.Tests/Megrez.Tests.csproj
+++ b/Megrez.Tests/Megrez.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.2.8</ReleaseVersion>
+    <ReleaseVersion>1.2.9</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Megrez.Tests/MegrezTests.cs
+++ b/Megrez.Tests/MegrezTests.cs
@@ -23,261 +23,498 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 
 namespace Megrez.Tests;
 
-public class MegrezTests {
+public class MegrezTests : TestDataClass {
   [Test]
-  public void TestInput() {
-    Console.WriteLine("// 開始測試語言文字輸入處理");
-    SimpleLM lmTestInput = new(TestClass.StrSampleData);
-    Compositor theCompositor = new(lmTestInput);
-    List<Megrez.NodeAnchor> walked = new();
+  public void Test01_SpanUnitInternalAbilities() {
+    SimpleLM langModel = new(input: StrSampleData);
+    SpanUnit span = new();
+    Node n1 = new(key: "gao", unigrams: langModel.UnigramsFor(key: "gao1"));
+    Node n3 = new(key: "gao1ke1ji4", unigrams: langModel.UnigramsFor(key: "gao1ke1ji4"));
+    Assert.AreEqual(actual: span.MaxLength, expected: 0);
+    span.Insert(node: n1, length: 1);
+    Assert.AreEqual(actual: span.MaxLength, expected: 1);
+    span.Insert(node: n3, length: 3);
+    Assert.AreEqual(actual: span.MaxLength, expected: 3);
+    Assert.AreEqual(actual: span.NodeOf(length: 1), expected: n1);
+    Assert.AreEqual(actual: span.NodeOf(length: 2), expected: null);
+    Assert.AreEqual(actual: span.NodeOf(length: 3), expected: n3);
+    span.Clear();
+    Assert.AreEqual(actual: span.MaxLength, expected: 0);
+    Assert.AreEqual(actual: span.NodeOf(length: 1), expected: null);
+    Assert.AreEqual(actual: span.NodeOf(length: 2), expected: null);
+    Assert.AreEqual(actual: span.NodeOf(length: 3), expected: null);
 
-    void Walk() { walked = theCompositor.Walk(); }
-
-    // 模擬輸入法的行為，每次敲字或選字都重新 walk。;
-    theCompositor.insertReading("gao1");
-    Walk();
-    theCompositor.insertReading("ji4");
-    Walk();
-    theCompositor.Cursor = 1;
-    theCompositor.insertReading("ke1");
-    Walk();
-    theCompositor.Cursor = 1;
-    theCompositor.DropReading(Compositor.TypingDirection.ToFront);
-    Walk();
-    theCompositor.insertReading("ke1");
-    Walk();
-    theCompositor.Cursor = 0;
-    theCompositor.DropReading(Compositor.TypingDirection.ToFront);
-    Walk();
-    theCompositor.insertReading("gao1");
-    Walk();
-    theCompositor.Cursor = theCompositor.Length;
-    theCompositor.insertReading("gong1");
-    Walk();
-    theCompositor.insertReading("si1");
-    Walk();
-    theCompositor.insertReading("de5");
-    Walk();
-    theCompositor.insertReading("nian2");
-    Walk();
-    theCompositor.insertReading("zhong1");
-    Walk();
-    theCompositor.FixNodeSelectedCandidate(new("nian2zhong1", "年終"), 7);
-    Walk();
-    theCompositor.insertReading("jiang3");
-    Walk();
-    theCompositor.insertReading("jin1");
-    Walk();
-    theCompositor.insertReading("ni3");
-    Walk();
-    theCompositor.insertReading("zhe4");
-    Walk();
-    theCompositor.insertReading("yang4");
-    Walk();
-
-    // 這裡模擬一個輸入法的常見情況：每次敲一個字詞都會
-    // walk，然後你回頭編輯完一些內容之後又會立刻重新 walk。
-    // 如果只在這裡測試第一遍 walk 的話，測試通過了也無法測試之後再次 walk
-    // 是否會正常。
-    theCompositor.Cursor = 1;
-    theCompositor.DropReading(Compositor.TypingDirection.ToFront);
-
-    // 於是咱們 walk 第二遍
-    Walk();
-    Assert.False(walked.Count == 0);
-
-    // 做好第三遍的準備，這次咱們來一次插入性編輯。
-    // 重點測試這句是否正常，畢竟是在 walked 過的節點內進行插入編輯。
-    theCompositor.insertReading("ke1");
-
-    // 於是咱們 walk 第三遍。
-    // 這一遍會直接曝露「上述修改是否有對 TheCompositor 造成了破壞性的損失」，
-    // 所以很重要。
-    Walk();
-    Assert.False(walked.Count == 0);
-
-    List<string> composed = new();
-    foreach (Megrez.NodeAnchor phrase in walked) {
-      if (phrase.Node != null) composed.Add(phrase.Node.CurrentPair.Value);
-    }
-    Console.WriteLine(string.Join("_", composed));
-    List<string> correctResult = new List<string> { "高科技", "公司", "的", "年終", "獎金", "你", "這樣" };
-    Console.WriteLine(" - 上述列印結果理應於下面這行一致：");
-    Console.WriteLine(string.Join("_", correctResult));
-    Assert.AreEqual(string.Join("_", correctResult), string.Join("_", composed));
-
-    // 測試 DumpDOT
-    theCompositor.Cursor = theCompositor.Length;
-    theCompositor.DropReading(Compositor.TypingDirection.ToRear);
-    theCompositor.DropReading(Compositor.TypingDirection.ToRear);
-    theCompositor.DropReading(Compositor.TypingDirection.ToRear);
-    string expectedDumpDOT =
-        "digraph {\ngraph [ rankdir=LR ];\nBOS;\nBOS -> 高;\n高;\n高 -> 科;\n高 -> 科技;\nBOS -> 高科技;\n高科技;\n高科技 -> 工;\n高科技 -> 公司;\n科;\n科 -> 際;\n科 -> 濟公;\n科技;\n科技 -> 工;\n科技 -> 公司;\n際;\n際 -> 工;\n際 -> 公司;\n濟公;\n濟公 -> 斯;\n工;\n工 -> 斯;\n公司;\n公司 -> 的;\n斯;\n斯 -> 的;\n的;\n的 -> 年;\n的 -> 年終;\n年;\n年 -> 中;\n年終;\n年終 -> 獎;\n年終 -> 獎金;\n中;\n中 -> 獎;\n中 -> 獎金;\n獎;\n獎 -> 金;\n獎金;\n獎金 -> EOS;\n金;\n金 -> EOS;\nEOS;\n}\n";
-    Assert.AreEqual(expectedDumpDOT, theCompositor.DumpDOT());
+    span.Insert(node: n1, length: 1);
+    span.Insert(node: n3, length: 3);
+    span.DropNodesBeyond(length: 1);
+    Assert.AreEqual(actual: span.MaxLength, expected: 1);
+    Assert.AreEqual(actual: span.NodeOf(length: 1), expected: n1);
+    Assert.AreEqual(actual: span.NodeOf(length: 2), expected: null);
+    Assert.AreEqual(actual: span.NodeOf(length: 3), expected: null);
+    span.DropNodesBeyond(length: 0);
+    Assert.AreEqual(actual: span.MaxLength, expected: 0);
+    Assert.AreEqual(actual: span.NodeOf(length: 1), expected: null);
   }
 
   [Test]
-  public void TestWordSegmentation() {
-    Console.WriteLine("// 開始測試語句分節處理");
-    SimpleLM lmTestInput = new(TestClass.StrSampleData, true);
-    Compositor theCompositor = new(lmTestInput, separator: "");
-    List<Megrez.NodeAnchor> walked = new();
+  public void Test02_BasicFeaturesOfCompositor() {
+    Compositor compositor = new(lm: new MockLM(), separator: "");
+    Assert.AreEqual(actual: compositor.JoinSeparator, expected: "");
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Length, expected: 0);
 
-    void Walk(int location) { walked = theCompositor.Walk(); }
+    Assert.IsTrue(compositor.InsertReading("a"));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 1);
+    Assert.AreEqual(actual: compositor.Length, expected: 1);
+    Assert.AreEqual(actual: compositor.Width, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 1);
+    if (compositor.Spans[0].NodeOf(length: 1) is not {} zeroNode) return;
+    Assert.AreEqual(actual: zeroNode.Key, expected: "a");
 
-    // 模擬輸入法的行為，每次敲字或選字都重新 walk。;
-    theCompositor.insertReading("高");
-    theCompositor.insertReading("科");
-    theCompositor.insertReading("技");
-    theCompositor.insertReading("公");
-    theCompositor.insertReading("司");
-    theCompositor.insertReading("的");
-    theCompositor.insertReading("年");
-    theCompositor.insertReading("終");
-    theCompositor.insertReading("獎");
-    theCompositor.insertReading("金");
-
-    Walk(location: 0);
-    List<string> segmented = new();
-    foreach (Megrez.NodeAnchor phrase in walked) {
-      if (phrase.Node != null) segmented.Add(phrase.Node.CurrentPair.Key);
-    }
-    Console.WriteLine(string.Join("_", segmented));
-    List<string> correctResult = new List<string> { "高科技", "公司", "的", "年終", "獎金" };
-    Console.WriteLine(" - 上述列印結果理應於下面這行一致：");
-    Console.WriteLine(string.Join("_", correctResult));
-    Assert.AreEqual(string.Join("_", correctResult), string.Join("_", segmented));
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Width, expected: 0);
   }
-}
 
-public class SimpleLM : LangModelProtocol {
-  private Dictionary<string, List<Unigram>> _database = new();
-  public SimpleLM(string input, bool swapKeyValue = false) {
-    List<string> sStream = new(input.Split('\n'));
-    foreach (string line in sStream) {
-      if (line.Length == 0 || line.FirstOrDefault().CompareTo('#') == 0) continue;
-      List<string> lineStream = new(line.Split(' '));
-      if (lineStream.Count >= 2) {
-        string col0 = lineStream[0];  // 假設其不為 nil
-        string col1 = lineStream[1];  // 假設其不為 nil
-        double col2 = 0;              // 防呆
-        if (lineStream.Count >= 3 && Double.TryParse(lineStream[2], out double number)) col2 = number;
-        Unigram u = new(new KeyValuePaired(), 0);
-        if (swapKeyValue)
-          u.KeyValue = new(col1, col0);
-        else
-          u.KeyValue = new(col0, col1);
-        u.Score = col2;
-        if (!_database.ContainsKey(u.KeyValue.Key)) _database.Add(u.KeyValue.Key, new List<Unigram> {});
-        _database[u.KeyValue.Key].Add(u);
-      }
-    }
+  [Test]
+  public void Test03_InvalidOperations() {
+    Compositor compositor = new(lm: new TestLM(), separator: ";");
+    Assert.IsFalse(compositor.InsertReading("bar"));
+    Assert.IsFalse(compositor.InsertReading(""));
+    Assert.IsFalse(compositor.InsertReading(""));
+    Assert.IsFalse(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.IsFalse(compositor.DropReading(direction: Compositor.TypingDirection.ToFront));
+
+    compositor.InsertReading("foo");
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Length, expected: 0);
+    compositor.InsertReading("foo");
+    compositor.Cursor = 0;
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Length, expected: 0);
   }
-  public List<Bigram> BigramsForKeys(string precedingKey, string key) { return new(); }
-  public List<Unigram> UnigramsFor(string key) => _database.ContainsKey(key) ? _database[key] : new();
-  public bool HasUnigramsFor(string key) => _database.ContainsKey(key);
-}
 
-public class TestClass {
-  public static string StrSampleData =
-      @"
-#
-# 下述詞頻資料取自 libTaBE 資料庫 (http://sourceforge.net/projects/libtabe/)
-# (2002 最終版). 該專案於 1999 年由 Pai-Hsiang Hsiao 發起、以 BSD 授權發行。
-#
+  [Test]
+  public void Test04_DeleteToTheFrontOfCursor() {
+    Compositor compositor = new(lm: new MockLM());
+    compositor.InsertReading("a");
+    compositor.Cursor = 0;
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Length, expected: 1);
+    Assert.AreEqual(actual: compositor.Width, expected: 1);
+    Assert.IsFalse(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Length, expected: 1);
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Length, expected: 0);
+    Assert.AreEqual(actual: compositor.Width, expected: 0);
+  }
 
-ni3 你 -6.000000 // Non-LibTaBE
-zhe4 這 -6.000000 // Non-LibTaBE
-yang4 樣 -6.000000 // Non-LibTaBE
-si1 絲 -9.495858
-si1 思 -9.006414
-si1 私 -99.000000
-si1 斯 -8.091803
-si1 司 -99.000000
-si1 嘶 -13.513987
-si1 撕 -12.259095
-gao1 高 -7.171551
-ke1 顆 -10.574273
-ke1 棵 -11.504072
-ke1 刻 -10.450457
-ke1 科 -7.171052
-ke1 柯 -99.000000
-gao1 膏 -11.928720
-gao1 篙 -13.624335
-gao1 糕 -12.390804
-de5 的 -3.516024
-di2 的 -3.516024
-di4 的 -3.516024
-zhong1 中 -5.809297
-de5 得 -7.427179
-gong1 共 -8.381971
-gong1 供 -8.501463
-ji4 既 -99.000000
-jin1 今 -8.034095
-gong1 紅 -8.858181
-ji4 際 -7.608341
-ji4 季 -99.000000
-jin1 金 -7.290109
-ji4 騎 -10.939895
-zhong1 終 -99.000000
-ji4 記 -99.000000
-ji4 寄 -99.000000
-jin1 斤 -99.000000
-ji4 繼 -9.715317
-ji4 計 -7.926683
-ji4 暨 -8.373022
-zhong1 鐘 -9.877580
-jin1 禁 -10.711079
-gong1 公 -7.877973
-gong1 工 -7.822167
-gong1 攻 -99.000000
-gong1 功 -99.000000
-gong1 宮 -99.000000
-zhong1 鍾 -9.685671
-ji4 繫 -10.425662
-gong1 弓 -99.000000
-gong1 恭 -99.000000
-ji4 劑 -8.888722
-ji4 祭 -10.204425
-jin1 浸 -11.378321
-zhong1 盅 -99.000000
-ji4 忌 -99.000000
-ji4 技 -8.450826
-jin1 筋 -11.074890
-gong1 躬 -99.000000
-ji4 冀 -12.045357
-zhong1 忠 -99.000000
-ji4 妓 -99.000000
-ji4 濟 -9.517568
-ji4 薊 -12.021587
-jin1 巾 -99.000000
-jin1 襟 -12.784206
-nian2 年 -6.086515
-jiang3 講 -9.164384
-jiang3 獎 -8.690941
-jiang3 蔣 -10.127828
-nian2 黏 -11.336864
-nian2 粘 -11.285740
-jiang3 槳 -12.492933
-gong1si1 公司 -6.299461
-ke1ji4 科技 -6.736613
-ji4gong1 濟公 -13.336653
-jiang3jin1 獎金 -10.344678
-nian2zhong1 年終 -11.668947
-nian2zhong1 年中 -11.373044
-gao1ke1ji4 高科技 -9.842421
-zhe4yang4 這樣 -6.000000 // Non-LibTaBE
-ni3zhe4 你這 -9.000000 // Non-LibTaBE
-jiao4 教 -3.676169
-jiao4 較 -3.24869962
-jiao4yu4 教育 -3.32220565
-yu4 育 -3.30192952
-  ";
+  [Test]
+  public void Test05_MultipleSpanUnits() {
+    Compositor compositor = new(lm: new MockLM(), separator: ";");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    Assert.AreEqual(actual: compositor.Cursor, expected: 3);
+    Assert.AreEqual(actual: compositor.Length, expected: 3);
+    Assert.AreEqual(actual: compositor.Width, expected: 3);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 3);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 1)?.Key, expected: "a");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 2)?.Key, expected: "a;b");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 3)?.Key, expected: "a;b;c");
+    Assert.AreEqual(actual: compositor.Spans[1].MaxLength, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 1)?.Key, expected: "b");
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 2)?.Key, expected: "b;c");
+    Assert.AreEqual(actual: compositor.Spans[2].MaxLength, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[2].NodeOf(length: 1)?.Key, expected: "c");
+  }
+
+  [Test]
+  public void Test06_SpanUnitDeletionFromFront() {
+    Compositor compositor = new(lm: new MockLM(), separator: ";");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    Assert.IsFalse(compositor.DropReading(direction: Compositor.TypingDirection.ToFront));
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 2);
+    Assert.AreEqual(actual: compositor.Length, expected: 2);
+    Assert.AreEqual(actual: compositor.Width, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 1)?.Key, expected: "a");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 2)?.Key, expected: "a;b");
+    Assert.AreEqual(actual: compositor.Spans[1].MaxLength, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 1)?.Key, expected: "b");
+  }
+
+  [Test]
+  public void Test07_SpanUnitDeletionFromMiddle() {
+    Compositor compositor = new(lm: new MockLM(), separator: ";");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    compositor.Cursor = 2;
+
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 1);
+    Assert.AreEqual(actual: compositor.Length, expected: 2);
+    Assert.AreEqual(actual: compositor.Width, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 1)?.Key, expected: "a");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 2)?.Key, expected: "a;c");
+    Assert.AreEqual(actual: compositor.Spans[1].MaxLength, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 1)?.Key, expected: "c");
+
+    compositor.Clear();
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    compositor.Cursor = 1;
+
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 1);
+    Assert.AreEqual(actual: compositor.Length, expected: 2);
+    Assert.AreEqual(actual: compositor.Width, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 1)?.Key, expected: "a");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 2)?.Key, expected: "a;c");
+    Assert.AreEqual(actual: compositor.Spans[1].MaxLength, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 1)?.Key, expected: "c");
+  }
+
+  [Test]
+  public void Test08_SpanUnitDeletionFromRear() {
+    Compositor compositor = new(lm: new MockLM(), separator: ";");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    compositor.Cursor = 0;
+
+    Assert.IsFalse(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.AreEqual(actual: compositor.Length, expected: 2);
+    Assert.AreEqual(actual: compositor.Width, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 1)?.Key, expected: "b");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 2)?.Key, expected: "b;c");
+    Assert.AreEqual(actual: compositor.Spans[1].MaxLength, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 1)?.Key, expected: "c");
+  }
+
+  [Test]
+  public void Test09_SpanUnitInsertion() {
+    Compositor compositor = new(lm: new MockLM(), separator: ";");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    compositor.Cursor = 1;
+    compositor.InsertReading("X");
+
+    Assert.AreEqual(actual: compositor.Cursor, expected: 2);
+    Assert.AreEqual(actual: compositor.Length, expected: 4);
+    Assert.AreEqual(actual: compositor.Width, expected: 4);
+    Assert.AreEqual(actual: compositor.Spans[0].MaxLength, expected: 4);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 1)?.Key, expected: "a");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 2)?.Key, expected: "a;X");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 3)?.Key, expected: "a;X;b");
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 4)?.Key, expected: "a;X;b;c");
+    Assert.AreEqual(actual: compositor.Spans[1].MaxLength, expected: 3);
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 1)?.Key, expected: "X");
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 2)?.Key, expected: "X;b");
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 3)?.Key, expected: "X;b;c");
+    Assert.AreEqual(actual: compositor.Spans[2].MaxLength, expected: 2);
+    Assert.AreEqual(actual: compositor.Spans[2].NodeOf(length: 1)?.Key, expected: "b");
+    Assert.AreEqual(actual: compositor.Spans[2].NodeOf(length: 2)?.Key, expected: "b;c");
+    Assert.AreEqual(actual: compositor.Spans[3].MaxLength, expected: 1);
+    Assert.AreEqual(actual: compositor.Spans[3].NodeOf(length: 1)?.Key, expected: "c");
+  }
+
+  [Test]
+  public void Test10_LongGridDeletion() {
+    Compositor compositor = new(lm: new MockLM(), separator: "");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    compositor.InsertReading("d");
+    compositor.InsertReading("e");
+    compositor.InsertReading("f");
+    compositor.InsertReading("g");
+    compositor.InsertReading("h");
+    compositor.InsertReading("i");
+    compositor.InsertReading("j");
+    compositor.InsertReading("k");
+    compositor.InsertReading("l");
+    compositor.InsertReading("m");
+    compositor.InsertReading("n");
+    compositor.Cursor = 7;
+    Assert.IsTrue(compositor.DropReading(direction: Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 6);
+    Assert.AreEqual(actual: compositor.Length, expected: 13);
+    Assert.AreEqual(actual: compositor.Width, expected: 13);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 6)?.Key, expected: "abcdef");
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 6)?.Key, expected: "bcdefh");
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 5)?.Key, expected: "bcdef");
+    Assert.AreEqual(actual: compositor.Spans[2].NodeOf(length: 6)?.Key, expected: "cdefhi");
+    Assert.AreEqual(actual: compositor.Spans[2].NodeOf(length: 5)?.Key, expected: "cdefh");
+    Assert.AreEqual(actual: compositor.Spans[3].NodeOf(length: 6)?.Key, expected: "defhij");
+    Assert.AreEqual(actual: compositor.Spans[4].NodeOf(length: 6)?.Key, expected: "efhijk");
+    Assert.AreEqual(actual: compositor.Spans[5].NodeOf(length: 6)?.Key, expected: "fhijkl");
+    Assert.AreEqual(actual: compositor.Spans[6].NodeOf(length: 6)?.Key, expected: "hijklm");
+    Assert.AreEqual(actual: compositor.Spans[7].NodeOf(length: 6)?.Key, expected: "ijklmn");
+    Assert.AreEqual(actual: compositor.Spans[8].NodeOf(length: 5)?.Key, expected: "jklmn");
+  }
+
+  [Test]
+  public void Test11_LongGridInsertion() {
+    Compositor compositor = new(lm: new MockLM(), separator: "");
+    compositor.InsertReading("a");
+    compositor.InsertReading("b");
+    compositor.InsertReading("c");
+    compositor.InsertReading("d");
+    compositor.InsertReading("e");
+    compositor.InsertReading("f");
+    compositor.InsertReading("g");
+    compositor.InsertReading("h");
+    compositor.InsertReading("i");
+    compositor.InsertReading("j");
+    compositor.InsertReading("k");
+    compositor.InsertReading("l");
+    compositor.InsertReading("m");
+    compositor.InsertReading("n");
+    compositor.Cursor = 7;
+    compositor.InsertReading("X");
+    Assert.AreEqual(actual: compositor.Cursor, expected: 8);
+    Assert.AreEqual(actual: compositor.Length, expected: 15);
+    Assert.AreEqual(actual: compositor.Width, expected: 15);
+    Assert.AreEqual(actual: compositor.Spans[0].NodeOf(length: 6)?.Key, expected: "abcdef");
+    Assert.AreEqual(actual: compositor.Spans[1].NodeOf(length: 6)?.Key, expected: "bcdefg");
+    Assert.AreEqual(actual: compositor.Spans[2].NodeOf(length: 6)?.Key, expected: "cdefgX");
+    Assert.AreEqual(actual: compositor.Spans[3].NodeOf(length: 6)?.Key, expected: "defgXh");
+    Assert.AreEqual(actual: compositor.Spans[3].NodeOf(length: 5)?.Key, expected: "defgX");
+    Assert.AreEqual(actual: compositor.Spans[4].NodeOf(length: 6)?.Key, expected: "efgXhi");
+    Assert.AreEqual(actual: compositor.Spans[4].NodeOf(length: 5)?.Key, expected: "efgXh");
+    Assert.AreEqual(actual: compositor.Spans[4].NodeOf(length: 4)?.Key, expected: "efgX");
+    Assert.AreEqual(actual: compositor.Spans[4].NodeOf(length: 3)?.Key, expected: "efg");
+    Assert.AreEqual(actual: compositor.Spans[5].NodeOf(length: 6)?.Key, expected: "fgXhij");
+    Assert.AreEqual(actual: compositor.Spans[6].NodeOf(length: 6)?.Key, expected: "gXhijk");
+    Assert.AreEqual(actual: compositor.Spans[7].NodeOf(length: 6)?.Key, expected: "Xhijkl");
+    Assert.AreEqual(actual: compositor.Spans[8].NodeOf(length: 6)?.Key, expected: "hijklm");
+  }
+
+  [Test]
+  public void Test12_WordSegmentation() {
+    Compositor compositor = new(lm: new SimpleLM(input: StrSampleData, swapKeyValue: true)) { JoinSeparator = "" };
+    string testStr = "高科技公司的年終獎金";
+    foreach (char c in testStr) compositor.InsertReading(c.ToString());
+    Assert.AreEqual(actual: compositor.Walk().Keys(),
+                    expected: new List<string> { "高科技", "公司", "的", "年終", "獎金" });
+  }
+
+  [Test]
+  public void Test13_LanguageInputAndCursorJump() {
+    Compositor compositor = new(lm: new SimpleLM(input: StrSampleData), separator: "");
+    compositor.InsertReading("gao1");
+    compositor.InsertReading("ji4");
+    compositor.Cursor = 1;
+    compositor.InsertReading("ke1");
+    compositor.Cursor = 0;
+    compositor.DropReading(direction: Compositor.TypingDirection.ToFront);
+    compositor.InsertReading("gao1");
+    compositor.Cursor = compositor.Length;
+    compositor.InsertReading("gong1");
+    compositor.InsertReading("si1");
+    compositor.InsertReading("de5");
+    compositor.InsertReading("nian2");
+    compositor.InsertReading("zhong1");
+    compositor.InsertReading("jiang3");
+    compositor.InsertReading("jin1");
+    Console.WriteLine("// Normal walk: Time test started.");
+    DateTime startTime = DateTime.Now;
+    compositor.Walk();
+    TimeSpan timeElapsed = DateTime.Now - startTime;
+    Console.WriteLine($"// Normal walk: Time test elapsed: {timeElapsed.TotalSeconds}s.");
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(),
+                    expected: new List<string> { "高科技", "公司", "的", "年中", "獎金" });
+    Assert.AreEqual(actual: compositor.Length, expected: 10);
+    Assert.False(compositor.FixNodeWithCandidate(new(key: "nian2zhong1", value: "年終"), 7).IsEmpty);
+    compositor.Cursor = 8;
+    Assert.False(compositor.FixNodeWithCandidate(new(key: "nian2zhong1", value: "年終"), compositor.Cursor).IsEmpty);
+    compositor.Walk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(),
+                    expected: new List<string> { "高科技", "公司", "的", "年終", "獎金" });
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 6);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 5);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 3);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.IsFalse(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToRear));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 0);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 3);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 5);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 6);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 8);
+    Assert.IsTrue(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 10);
+    Assert.IsFalse(compositor.JumpCursorBySpan(Compositor.TypingDirection.ToFront));
+    Assert.AreEqual(actual: compositor.Cursor, expected: 10);
+    compositor.FastWalk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(),
+                    expected: new List<string> { "高科技", "公司", "的", "年終", "獎金" });
+  }
+  [Test]
+  public void Test14_OverrideOverlappingNodes() {
+    Compositor compositor = new(lm: new SimpleLM(input: StrSampleData)) { JoinSeparator = "" };
+    compositor.InsertReading("gao1");
+    compositor.InsertReading("ke1");
+    compositor.InsertReading("ji4");
+    compositor.Cursor = 1;
+    compositor.FixNodeWithCandidateLiteral("膏", compositor.Cursor);
+    List<NodeAnchor> result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "膏", "科技" });
+    compositor.FixNodeWithCandidateLiteral("高科技", 2);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高科技" });
+    compositor.FixNodeWithCandidateLiteral("膏", 1);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "膏", "科技" });
+
+    compositor.FixNodeWithCandidateLiteral("柯", 2);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "膏", "柯", "際" });
+
+    compositor.FixNodeWithCandidateLiteral("暨", 3);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "膏", "柯", "暨" });
+
+    compositor.FixNodeWithCandidateLiteral("高科技", 3);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高科技" });
+  }
+  [Test]
+  public void Test15_OverrideReset() {
+    string newSampleData = StrSampleData + "zhong1jiang3 終講 -11.0\n" + "jiang3jin1 槳襟 -11.0\n";
+    Compositor compositor = new(lm: new SimpleLM(input: newSampleData), separator: "");
+    compositor.InsertReading("nian2");
+    compositor.InsertReading("zhong1");
+    compositor.InsertReading("jiang3");
+    compositor.InsertReading("jin1");
+    compositor.Walk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(), expected: new List<string> { "年中", "獎金" });
+
+    compositor.FixNodeWithCandidateLiteral("終講", 2);
+    compositor.Walk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(), expected: new List<string> { "年", "終講", "金" });
+
+    compositor.FixNodeWithCandidateLiteral("槳襟", 3);
+    compositor.Walk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(), expected: new List<string> { "年中", "槳襟" });
+
+    compositor.FixNodeWithCandidateLiteral("年終", 1);
+    compositor.Walk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(), expected: new List<string> { "年終", "槳襟" });
+  }
+  [Test]
+  public void Test16_CandidateDisambiguation() {
+    Compositor compositor = new(lm: new SimpleLM(input: StrEmojiSampleData), separator: "");
+    compositor.InsertReading("gao1");
+    compositor.InsertReading("re4");
+    compositor.InsertReading("huo3");
+    compositor.InsertReading("yan4");
+    compositor.InsertReading("wei2");
+    compositor.InsertReading("xian3");
+    compositor.InsertReading("mi4");
+    compositor.InsertReading("feng1");
+    List<NodeAnchor>? result = compositor.FastWalk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高熱", "火焰", "危險", "蜜蜂" });
+
+    compositor.FixNodeWithCandidate(new(key: "huo3", value: "🔥"), 3);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高熱", "🔥", "焰", "危險", "蜜蜂" });
+
+    compositor.FixNodeWithCandidate(new(key: "huo3yan4", value: "🔥"), 4);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高熱", "🔥", "危險", "蜜蜂" });
+
+    compositor.Cursor = compositor.Width;
+
+    compositor.FixNodeWithCandidate(new(key: "mi4feng1", value: "🐝"), compositor.Cursor);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高熱", "🔥", "危險", "🐝" });
+
+    compositor.FixNodeWithCandidate(new(key: "feng1", value: "🐝"), compositor.Cursor);
+    result = compositor.Walk();
+    Assert.AreEqual(actual: result.Values(), expected: new List<string> { "高熱", "🔥", "危險", "蜜", "🐝" });
+  }
+
+  [Test]
+  public void Test17_StressBenchmark_MachineGun() {
+    // 測試結果發現：只敲入完全雷同的某個漢字的話，想保證使用體驗就得讓一個組字區最多塞 20 字。
+    Console.WriteLine("// Normal walk: Machine-Gun Stress test preparation begins.");
+    Compositor compositor = new(lm: new SimpleLM(input: StrStressData));
+    // 這個測試最多只能塞 20 字，否則會慢死。;
+    for (int i = 0; i < 20; i += 1) compositor.InsertReading("yi1");
+    Console.WriteLine("// Normal walk: Machine-Gun Stress test started.");
+    DateTime startTime = DateTime.Now;
+    compositor.Walk();
+    TimeSpan timeElapsed = DateTime.Now - startTime;
+    Console.WriteLine($"// Normal walk: Machine-Gun Stress test elapsed: {timeElapsed.TotalSeconds}s.");
+
+    // 再測試頂點（Vertex）算法：;
+    Console.WriteLine("// Vertex walk: Machine-Gun Stress test preparation begins.");
+    // 頂點算法可以爬超多的字。不過 Swift 在 insertReading 時就很慢。;
+    for (int i = 0; i < 2000; i += 1) compositor.InsertReading("yi1");
+    Console.WriteLine("// Vertex walk: Machine-Gun Stress test started.");
+    startTime = DateTime.Now;
+    compositor.FastWalk();
+    timeElapsed = DateTime.Now - startTime;
+    Console.WriteLine($"// Vertex walk: Machine-Gun Stress test elapsed: {timeElapsed.TotalSeconds}s.");
+  }
+
+  [Test]
+  public void Test18_StressBenchmark_SpeakLikeAHuman() {
+    // C# 的測試結果與 Swift 不同，只敲入完全雷同的某個漢字時的處理速度反而更快。
+    // 複雜輸入的話，一個組字區最多塞 20-30 字。不然很快就會遲鈍。
+    Compositor compositor = new(lm: new SimpleLM(input: StrSampleData), separator: "");
+    List<string> testMaterial =
+        new() { "gao1", "ke1", "ji4", "gong1", "si1", "de5", "nian2", "zhong1", "jiang3", "jin1" };
+    foreach (string neta in testMaterial) compositor.InsertReading(neta);
+    compositor.FastWalk();
+    Assert.AreEqual(actual: compositor.WalkedAnchors.Values(),
+                    expected: new List<string> { "高科技", "公司", "的", "年中", "獎金" });
+
+    foreach (string neta in testMaterial) compositor.InsertReading(neta);
+    foreach (string neta in testMaterial) compositor.InsertReading(neta);
+    Console.WriteLine("// Normal walk: Time test started.");
+    DateTime startTime = DateTime.Now;
+    compositor.Walk();
+    TimeSpan timeElapsed = DateTime.Now - startTime;
+    Console.WriteLine($"// Normal walk: Time test elapsed: {timeElapsed.TotalSeconds}s.");
+
+    // 換用頂點算法來測試。
+    for (int i = 0; i < 114; i += 1) {
+      foreach (string neta in testMaterial) compositor.InsertReading(neta);
+    }
+    Console.WriteLine("// Fast walk real test: Time test started.");
+    startTime = DateTime.Now;
+    compositor.FastWalk();
+    timeElapsed = DateTime.Now - startTime;
+    Console.WriteLine($"// Fast walk real test: Time test elapsed: {timeElapsed.TotalSeconds}s.");
+  }
 }

--- a/Megrez.sln
+++ b/Megrez.sln
@@ -52,6 +52,6 @@ Global
 		$0.DotNetNamingPolicy = $4
 		$4.DirectoryNamespaceAssociation = PrefixedHierarchical
 		$0.StandardHeader = $5
-		version = 1.2.8
+		version = 1.2.9
 	EndGlobalSection
 EndGlobal

--- a/Megrez/1_Compositor.cs
+++ b/Megrez/1_Compositor.cs
@@ -31,7 +31,20 @@ namespace Megrez {
 /// <summary>
 /// 組字器。
 /// </summary>
-public class Compositor {
+public partial class Compositor : Grid {
+  /// <summary>
+  /// 就文字輸入方向而言的方向。
+  /// </summary>
+  public enum TypingDirection {
+    /// <summary>
+    /// 前方。
+    /// </summary>
+    ToFront,
+    /// <summary>
+    /// 後方。
+    /// </summary>
+    ToRear
+  }
   /// <summary>
   /// 給被丟掉的節點路徑施加的負權重。
   /// </summary>
@@ -39,15 +52,11 @@ public class Compositor {
   /// <summary>
   /// 該組字器的游標位置。
   /// </summary>
-  private int _cursorIndex;
+  private int _cursor;
   /// <summary>
   /// 該組字器所使用的語言模型。
   /// </summary>
-  private LanguageModel _langModel;
-  /// <summary>
-  /// 公開：該組字器內可以允許的最大詞長。
-  /// </summary>
-  public int MaxBuildSpanLength => Grid.MaxBuildSpanLength;
+  private LangModelProtocol _langModel;
   /// <summary>
   /// 公開：多字讀音鍵當中用以分割漢字讀音的記號，預設為空。
   /// </summary>
@@ -55,18 +64,14 @@ public class Compositor {
   /// <summary>
   /// 公開：該組字器的游標位置。
   /// </summary>
-  public int CursorIndex {
-    get => _cursorIndex;
-    set => _cursorIndex = value < 0 ? 0 : Math.Min(value, Readings.Count);
+  public int Cursor {
+    get => _cursor;
+    set => _cursor = Math.Max(0, Math.Min(value, Readings.Count));
   }
   /// <summary>
-  /// 公開：該組字器是否為空。
+  /// 允許查詢當前游標位置屬於第幾個幅位座標（從 0 開始算）。
   /// </summary>
-  public bool IsEmpty => Grid.IsEmpty;
-  /// <summary>
-  /// 公開：該組字器的軌格（唯讀）。
-  /// </summary>
-  public Grid Grid { get; }
+  public Dictionary<int, int> CursorRegionMap { get; private set; } = new();
   /// <summary>
   /// 公開：該組字器的長度，也就是內建漢字讀音的數量（唯讀）。
   /// </summary>
@@ -75,57 +80,104 @@ public class Compositor {
   /// 公開：該組字器的讀音陣列（唯讀）。
   /// </summary>
   public List<string> Readings { get; } = new();
+
+  /// <summary>
+  /// 用以記錄爬過的節錨的陣列。
+  /// </summary>
+  public List<NodeAnchor> WalkedAnchors { get; private set; } = new();
+  /// <summary>
+  /// 該函式用以更新爬過的節錨的陣列。
+  /// </summary>
+  /// <param name="nodes">傳入的節點陣列。</param>
+  public void UpdateWalkedAnchors(List<Node> nodes) {
+    WalkedAnchors = new(from node in nodes select new NodeAnchor(node));
+  }
+
+  /// <summary>
+  /// 按幅位來前後移動游標。
+  /// </summary>
+  /// <param name="direction">移動方向。</param>
+  /// <returns>該操作是否順利完成。</returns>
+  public bool JumpCursorBySpan(TypingDirection direction) {
+    switch (direction) {
+      case TypingDirection.ToFront:
+        if (_cursor == Width) return false;
+        break;
+      case TypingDirection.ToRear:
+        if (_cursor == 0) return false;
+        break;
+    }
+    if (!CursorRegionMap.ContainsKey(_cursor)) return false;
+    int currentRegion = CursorRegionMap[_cursor];
+
+    int aRegionForward = Math.Max(currentRegion - 1, 0);
+    int currentRegionBorderRear = WalkedAnchors.Take(currentRegion).Sum(x => x.SpanLength);
+    if (_cursor == currentRegionBorderRear) {
+      switch (direction) {
+        case TypingDirection.ToFront:
+          _cursor = currentRegion > WalkedAnchors.Count ? Readings.Count
+                                                        : WalkedAnchors.Take(currentRegion + 1).Sum(x => x.SpanLength);
+          break;
+        case TypingDirection.ToRear:
+          _cursor = WalkedAnchors.Take(aRegionForward).Sum(a => a.SpanLength);
+          break;
+      }
+    } else {
+      switch (direction) {
+        case TypingDirection.ToFront:
+          _cursor = currentRegionBorderRear + WalkedAnchors[currentRegion].SpanLength;
+          break;
+        case TypingDirection.ToRear:
+          _cursor = currentRegionBorderRear;
+          break;
+      }
+    }
+    return true;
+  }
+
   /// <summary>
   /// 組字器。
   /// </summary>
-  /// <param name="lm">語言模型。可以是任何基於 Megrez.LanguageModel 的衍生型別。</param>
+  /// <param name="lm">語言模型。可以是任何基於 Megrez.LangModelProtocol 的衍生型別。</param>
   /// <param name="length">指定該組字器內可以允許的最大詞長，預設為 10 字。</param>
   /// <param name="separator">多字讀音鍵當中用以分割漢字讀音的記號，預設為空。</param>
-  public Compositor(LanguageModel lm, int length = 10, string separator = "") {
+  public Compositor(LangModelProtocol lm, int length = 10, string separator = "") : base(length) {
     _langModel = lm;
-    Grid = new(Math.Abs(length));
     JoinSeparator = separator;
   }
   /// <summary>
   /// 組字器自我清空專用函式。
   /// </summary>
-  public void Clear() {
-    _cursorIndex = 0;
+  public override void Clear() {
+    base.Clear();
+    _cursor = 0;
     Readings.Clear();
-    Grid.Clear();
+    WalkedAnchors.Clear();
   }
   /// <summary>
   /// 在游標位置插入給定的讀音。
   /// </summary>
   /// <param name="reading">要插入的讀音。</param>
-  public void InsertReadingAtCursor(string reading) {
-    Readings.Insert(_cursorIndex, reading);
-    Grid.ExpandGridByOneAt(_cursorIndex);
+  public bool InsertReading(string reading) {
+    if (string.IsNullOrEmpty(reading) || !_langModel.HasUnigramsFor(reading)) return false;
+    Readings.Insert(_cursor, reading);
+    ResizeGridByOneAt(_cursor, ResizeBehavior.Expand);
     Build();
-    _cursorIndex += 1;
-  }
-  /// <summary>
-  /// 朝著與文字輸入方向相反的方向、砍掉一個與游標相鄰的讀音。<br />
-  /// 在威注音的術語體系當中，「與文字輸入方向相反的方向」為向後（Rear）。
-  /// </summary>
-  /// <returns>結果是否成功執行。</returns>
-  public bool DeleteReadingAtTheRearOfCursor() {
-    if (_cursorIndex == 0) return false;
-    Readings.RemoveAt(_cursorIndex - 1);
-    _cursorIndex -= 1;
-    Grid.ShrinkGridByOneAt(_cursorIndex);
-    Build();
+    _cursor += 1;
     return true;
   }
   /// <summary>
-  /// 朝著往文字輸入方向、砍掉一個與游標相鄰的讀音。<br />
-  /// 在威注音的術語體系當中，「文字輸入方向」為向前（Front）。
+  /// 朝著指定方向砍掉一個與游標相鄰的讀音。<br />
+  /// 在威注音的術語體系當中，「與文字輸入方向相反的方向」為向後（Rear），反之則為向前（Front）。
+  /// <param name="direction">指定方向。</param>
   /// </summary>
   /// <returns>結果是否成功執行。</returns>
-  public bool DeleteReadingToTheFrontOfCursor() {
-    if (_cursorIndex == Readings.Count) return false;
-    Readings.RemoveAt(_cursorIndex);
-    Grid.ShrinkGridByOneAt(_cursorIndex);
+  public bool DropReading(TypingDirection direction) {
+    bool isBackSpace = direction == TypingDirection.ToRear;
+    if (Cursor == (isBackSpace ? 0 : Readings.Count)) return false;
+    Readings.RemoveAt(Cursor - (isBackSpace ? 1 : 0));
+    Cursor -= isBackSpace ? 1 : 0;
+    ResizeGridByOneAt(Cursor, ResizeBehavior.Shrink);
     Build();
     return true;
   }
@@ -140,10 +192,10 @@ public class Compositor {
     int theCount = Math.Abs(count);
     if (theCount > Length) return false;
     for (int I = 0; I < theCount; I++) {
-      if (_cursorIndex > 0) _cursorIndex -= 1;
+      if (_cursor > 0) _cursor -= 1;
       if (Readings.Count > 0) {
         Readings.RemoveAt(0);
-        Grid.ShrinkGridByOneAt(0);
+        ResizeGridByOneAt(0, ResizeBehavior.Shrink);
       }
       Build();
     }
@@ -152,62 +204,59 @@ public class Compositor {
   /// <summary>
   /// 對已給定的軌格按照給定的位置與條件進行正向爬軌。
   /// </summary>
-  /// <param name="location">開始爬軌的位置。</param>
-  /// <param name="accumulatedScore">給定累計權重，非必填參數。預設值為 0。</param>
-  /// <param name="joinedPhrase">用以統計累計長詞的內部參數，請勿主動使用。</param>
-  /// <param name="longPhrases">用以統計累計長詞的內部參數，請勿主動使用。</param>
   /// <returns>均有節點的節錨陣列。</returns>
-  public List<NodeAnchor> Walk(int location = 0, double accumulatedScore = 0.0, string joinedPhrase = "",
-                               List<string>? longPhrases = default(List<string>)) {
-    int newLocation = Grid.Width - Math.Abs(location);
-    List<NodeAnchor> result = ReverseWalk(newLocation, accumulatedScore, joinedPhrase, longPhrases);
-    result.Reverse();
-    return result;
+  public List<NodeAnchor> Walk() {
+    int newLocation = Width;
+    WalkedAnchors = ReverseWalk(newLocation);
+    WalkedAnchors.Reverse();
+    WalkedAnchors = WalkedAnchors.Where(anchor => !anchor.IsEmpty).ToList();
+    UpdateCursorJumpingTables(WalkedAnchors);
+    return WalkedAnchors;
   }
+
+  // MARK: - Private Functions
+
   /// <summary>
-  /// 對已給定的軌格按照給定的位置與條件進行反向爬軌。
+  /// 內部專用反芻函式，對已給定的軌格按照給定的位置與條件進行反向爬軌。
   /// </summary>
   /// <param name="location">開始爬軌的位置。</param>
-  /// <param name="accumulatedScore">給定累計權重，非必填參數。預設值為 0。</param>
+  /// <param name="mass">給定累計權重，非必填參數。預設值為 0。</param>
   /// <param name="joinedPhrase">用以統計累計長詞的內部參數，請勿主動使用。</param>
   /// <param name="longPhrases">用以統計累計長詞的內部參數，請勿主動使用。</param>
   /// <returns>均有節點的節錨陣列。</returns>
-  public List<NodeAnchor> ReverseWalk(int location, double accumulatedScore = 0.0, string joinedPhrase = "",
-                                      List<string>? longPhrases = default(List<string>)) {
+  private List<NodeAnchor> ReverseWalk(int location, double mass = 0.0, string joinedPhrase = "",
+                                       List<string>? longPhrases = default(List<string>)) {
     longPhrases ??= new();
     location = Math.Abs(location);
-    if (location == 0 || location > Grid.Width) return new();
+    if (location == 0 || location > Width) return new();
     List<List<NodeAnchor>> paths = new();
-    List<NodeAnchor> nodes = Grid.NodesEndingAt(location);
-    nodes = nodes.OrderByDescending(a => a.ScoreForSort).ToList();
-    if (nodes.FirstOrDefault().Node == null) return new();
-
-    Node zeroNode = nodes.FirstOrDefault().Node ?? new("", new());
+    List<NodeAnchor> nodes = NodesEndingAt(location).OrderByDescending(a => a.ScoreForSort).ToList();
+    if (nodes.Count == 0) return new();
+    Node zeroNode = nodes.FirstOrDefault().Node;
 
     if (zeroNode.Score >= Node.ConSelectedCandidateScore) {
       NodeAnchor zeroAnchor = nodes.FirstOrDefault();
-      zeroAnchor.AccumulatedScore = accumulatedScore + zeroNode.Score;
-      List<NodeAnchor> path = ReverseWalk(location - zeroAnchor.SpanningLength, zeroAnchor.AccumulatedScore);
+      zeroAnchor.Mass = mass + zeroNode.Score;
+      List<NodeAnchor> path = ReverseWalk(location - zeroAnchor.SpanLength, zeroAnchor.Mass);
       path.Insert(0, zeroAnchor);
       paths.Add(path);
     } else if (longPhrases.Count > 0) {
       List<NodeAnchor> path = new();
       foreach (NodeAnchor T in nodes) {
         NodeAnchor theAnchor = T;
-        if (theAnchor.Node == null) continue;
         Node theNode = theAnchor.Node;
-        string joinedValue = theNode.CurrentKeyValue + joinedPhrase;
+        string joinedValue = theNode.CurrentPair + joinedPhrase;
         // 如果只是一堆單漢字的節點組成了同樣的長詞的話，直接棄用這個節點路徑。
         // 打比方說「八/月/中/秋/山/林/涼」與「八月/中秋/山林/涼」在使用者來看
         // 是「結果等價」的，那就扔掉前者。
         if (longPhrases.Contains(joinedValue)) {
-          theAnchor.AccumulatedScore = ConDroppedPathScore;
+          theAnchor.Mass = ConDroppedPathScore;
           path.Insert(0, theAnchor);
           paths.Add(path);
           continue;
         }
-        theAnchor.AccumulatedScore = accumulatedScore + theNode.Score;
-        path = ReverseWalk(location - theAnchor.SpanningLength, theAnchor.AccumulatedScore,
+        theAnchor.Mass = mass + theNode.Score;
+        path = ReverseWalk(location - theAnchor.SpanLength, theAnchor.Mass,
                            joinedValue.Length >= (longPhrases.FirstOrDefault() ?? "").Length ? "" : joinedValue,
                            longPhrases);
         path.Insert(0, theAnchor);
@@ -216,46 +265,58 @@ public class Compositor {
     } else {
       // 看看當前格位有沒有更長的候選字詞。
       longPhrases.Clear();
-      longPhrases.AddRange(from theAnchor in nodes where theAnchor.Node != null let theNode = theAnchor.Node where theAnchor.SpanningLength > 1 select theNode.CurrentKeyValue.Value);
+      longPhrases.AddRange(from theAnchor in nodes where theAnchor.Node != null let theNode = theAnchor.Node where theAnchor.SpanLength > 1 select theNode.CurrentPair.Value);
       longPhrases = longPhrases.OrderByDescending(a => a.Length).ToList();
       foreach (NodeAnchor T in nodes) {
         NodeAnchor theAnchor = T;
-        if (theAnchor.Node == null) continue;
         Node theNode = theAnchor.Node;
-        theAnchor.AccumulatedScore = accumulatedScore + theNode.Score;
-        List<NodeAnchor> path =
-            ReverseWalk(location - theAnchor.SpanningLength, theAnchor.AccumulatedScore,
-                        theAnchor.SpanningLength > 1 ? "" : theNode.CurrentKeyValue.Value, longPhrases);
+        theAnchor.Mass = mass + theNode.Score;
+        List<NodeAnchor> path = ReverseWalk(location - theAnchor.SpanLength, theAnchor.Mass,
+                                            theAnchor.SpanLength > 1 ? "" : theNode.CurrentPair.Value, longPhrases);
         path.Insert(0, theAnchor);
         paths.Add(path);
       }
     }
 
     List<NodeAnchor> result = paths.FirstOrDefault() ?? new();
-    foreach (List<NodeAnchor> neta in paths.Where(neta => neta.LastOrDefault().AccumulatedScore >
-                                                          result.LastOrDefault().AccumulatedScore)) {
+    foreach (List<NodeAnchor> neta in paths.Where(neta => neta.LastOrDefault().Mass > result.LastOrDefault().Mass)) {
       result = neta;
     }
 
-    return result;
+    return result;  // 空節點過濾的步驟交給 Walk() 這個對外函式，以避免重複執行清理步驟。
   }
-  // MARK: - Private Functions
+
   private void Build() {
-    int itrBegin = _cursorIndex < MaxBuildSpanLength ? 0 : _cursorIndex - MaxBuildSpanLength;
-    int itrEnd = Math.Min(_cursorIndex + MaxBuildSpanLength, Readings.Count);
+    int itrBegin = _cursor < MaxBuildSpanLength ? 0 : _cursor - MaxBuildSpanLength;
+    int itrEnd = Math.Min(_cursor + MaxBuildSpanLength, Readings.Count);
     for (int p = itrBegin; p < itrEnd; p++) {
       for (int q = 1; q < MaxBuildSpanLength; q++) {
         if (p + q > itrEnd) break;
         List<string> arrSlice = Readings.GetRange(p, q);
         string combinedReading = Join(arrSlice, JoinSeparator);
-        if (Grid.HasMatchedNode(p, q, combinedReading)) continue;
+        if (HasMatchedNode(p, q, combinedReading)) continue;
         List<Unigram> unigrams = _langModel.UnigramsFor(combinedReading);
         if (unigrams.Count == 0) continue;
-        Node n = new(combinedReading, unigrams);
-        Grid.InsertNode(n, p, q);
+        Node n = new(key: combinedReading, spanLength: q, unigrams: unigrams);
+        InsertNode(n, p, q);
       }
     }
   }
+
+  private void UpdateCursorJumpingTables(List<NodeAnchor> anchors) {
+    Dictionary<int, int> cursorRegionMapDict = new();
+    cursorRegionMapDict[-1] = 0;  // 防呆
+    int counter = 0;
+    foreach ((NodeAnchor item, int index)anchor in anchors.Select((item, index) => (item, index))) {
+      for (int j = 0; j < anchor.item.SpanLength; j++) {
+        cursorRegionMapDict[counter] = anchor.index;
+        counter += 1;
+      }
+    }
+    cursorRegionMapDict[counter] = anchors.Count;
+    CursorRegionMap = cursorRegionMapDict;
+  }
+
   private static string Join(IEnumerable<string> slice, string separator) => string.Join(separator, slice.ToList());
 }
 }

--- a/Megrez/1_VertexWalker.cs
+++ b/Megrez/1_VertexWalker.cs
@@ -1,0 +1,273 @@
+// CSharpened by (c) 2022 and onwards The vChewing Project (MIT-NTL License).
+// Rebranded from (c) Lukhnos Liu's C++ library "Gramambular" (MIT License).
+/*
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+// NOTE: This file is optional. Its internal functions are not enabled yet and need to be fixed.
+
+namespace Megrez {
+/// <summary>
+/// 一個「有向無環圖的」的頂點單位。<br />
+/// 這是一個可變的數據結構，用於有向無環圖的構建和單源最短路徑的計算。
+/// </summary>
+class Vertex {
+  /// <summary>
+  /// 前述頂點。
+  /// </summary>
+  public Vertex? Prev;
+  /// <summary>
+  /// 自身屬下的頂點陣列。
+  /// </summary>
+  public List<Vertex> Edges = new();
+  /// <summary>
+  /// 該變數用於最短路徑的計算。<br />
+  /// 我們實際上是在計算具有最大權重的路徑，因此距離的初始值是負無窮的。<br />
+  /// 如果我們要計算最短的權重/距離，我們會將其初期值設為正無窮。
+  /// </summary>
+  public double Distance = double.MinValue;
+  /// <summary>
+  /// 在進行進行位相幾何排序時會用到的狀態標記。
+  /// </summary>
+  public bool TopologicallySorted;
+  public Node Node;
+  public Vertex(Node node) {
+    Node = node;
+    TopologicallySorted = false;
+  }
+
+  /// <summary>
+  /// 卸勁函式。<br />
+  /// 「卸勁 (relax)」一詞出自 Cormen 在 2001 年的著作「Introduction to Algorithms」的 585 頁。
+  /// </summary>
+  /// <param name="u">參照頂點，會在必要時成為 v 的前述頂點。</param>
+  /// <param name="v">要影響的頂點。</param>
+  public static Vertex Relax(Vertex u, Vertex v) {
+    // 從 u 到 w 的距離，也就是 v 的權重。
+    double w = v.Node.Score;
+    // 這裡計算最大權重：
+    // 如果 v 目前的距離值小於「u 的距離值＋w（w 是 u 到 w 的距離，也就是 v 的權重）」，
+    // 我們就更新 v 的距離及其前述頂點。
+    if (v.Distance < u.Distance + w) {
+      v.Distance = u.Distance + w;
+      v.Prev = u;
+    }
+    // C# 的 inout 函數某些情況下會讀不到參數指針，所以這裡直接改成回傳函數。
+    return v;
+  }
+
+  private struct StateOfSort {
+    public int EdgeIter;
+    public Vertex Vertex;
+    public Vertex EdgeItered => Vertex.Edges[EdgeIter];
+    public StateOfSort(Vertex vertex) {
+      Vertex = vertex;
+      EdgeIter = 0;
+    }
+  }
+
+  /// <summary>
+  /// 對持有單個根頂點的有向無環圖進行位相幾何排序（topological
+  /// sort）、且將排序結果以頂點陣列的形式給出。
+  /// </summary>
+  /// <remarks>
+  /// 這裡使用我們自己的堆棧和狀態定義實現了一個非遞迴版本，
+  /// 這樣我們就不會受到當前線程的堆棧大小的限制。
+  /// <example>以下是等價的原始算法。
+  /// <code>
+  /// void TopologicalSort(Vertex vertex) {
+  ///   (A list of Vertex) result = new();
+  ///   foreach (var vertexNode in vertex.Edges) {
+  ///     if (!vertexNode.TopologicallySorted) {
+  ///       DFS(vertexNode, result);
+  ///       vertexNode.TopologicallySorted = true;
+  ///     }
+  ///     result.Add(v);
+  ///   }
+  /// }
+  /// </code></example>
+  /// 至於遞迴版本則類似於 Cormen 在 2001 年的著作「Introduction to Algorithms」當中的樣子。
+  /// </remarks>
+  /// <param name="root">根頂點。</param>
+  /// <returns>排序結果（頂點陣列）。</returns>
+  public static List<Vertex> TopologicalSort(Vertex root) {
+    List<Vertex> result = new();
+    List<StateOfSort> theStack = new() { new(root) };
+    while (theStack.Last() is var state) {
+      if (state.EdgeIter != state.Vertex.Edges.Count) {
+        Vertex nextVertex = state.EdgeItered;
+        state.EdgeIter += 1;
+        if (!nextVertex.TopologicallySorted) {
+          theStack.Add(new(nextVertex));
+          continue;
+        }
+      }
+      state.Vertex.TopologicallySorted = true;
+      result.Add(state.Vertex);
+      theStack.RemoveAt(theStack.Count - 1);
+      if (theStack.Count == 0) break;  // C# 需要這句處理，不然一直鬼打牆。
+    }
+    return result;
+  }
+}
+
+public partial class Compositor {
+  /// <summary>
+  /// 爬軌結果。
+  /// </summary>
+  public struct WalkResult {
+    /// <summary>
+    /// 爬軌結果。
+    /// </summary>
+    /// <param name="nodes">爬軌結果內的節點陣列。</param>
+    /// <param name="vertices">統計爬軌過程當中牽涉的頂點數量。</param>
+    /// <param name="edges">統計爬軌過程當中牽涉的頂點邊界數量。</param>
+    public WalkResult(List<Node> nodes, int vertices = 0, int edges = 0) {
+      Nodes = nodes;
+      Vertices = vertices;
+      Edges = edges;
+    }
+    /// <summary>
+    /// 爬軌結果內的節點陣列。
+    /// </summary>
+    public List<Node> Nodes;
+    /// <summary>
+    /// 統計爬軌過程當中牽涉的頂點數量。
+    /// </summary>
+    public int Vertices;
+    /// <summary>
+    /// 統計爬軌過程當中牽涉的頂點邊界數量。
+    /// </summary>
+    public int Edges;
+    /// <summary>
+    /// 獲取爬軌結果當中的資料值陣列。
+    /// </summary>
+    /// <returns>資料值陣列。</returns>
+    public string[] Values() => Nodes.Select(x => x.CurrentPair.Value).ToArray();
+    /// <summary>
+    /// 獲取爬軌結果當中的索引鍵陣列。
+    /// </summary>
+    /// <returns>索引鍵陣列。</returns>
+    public string[] Keys() => Nodes.Select(x => x.CurrentPair.Key).ToArray();
+  }
+
+  /// <summary>
+  /// 對已給定的軌格，使用頂點算法，按照給定的位置與條件進行正向爬軌。
+  /// </summary>
+  /// <remarks>⚠︎ 該方法有已知問題，會無視 fixNodeWithCandidate() 的前置操作效果。</remarks>
+  /// <returns>一個包含有效結果的節錨陣列。</returns>
+  public List<NodeAnchor> FastWalk() {
+    VertexWalk();
+    UpdateCursorJumpingTables(WalkedAnchors);
+    return WalkedAnchors;
+  }
+
+  /// <summary>
+  /// 找到軌格陣圖內權重最大的路徑。該路徑代表了可被觀測到的最可能的隱藏事件鏈。
+  /// 這裡使用 Cormen 在 2001 年出版的教材當中提出的「有向無環圖的最短路徑」的
+  /// 算法來計算這種路徑。不過，這裡不是要計算距離最短的路徑，而是計算距離最長
+  /// 的路徑（所以要找最大的權重），因為在對數概率下，較大的數值意味著較大的概率。
+  /// 對於 <c>G = (V, E)</c>，該算法的運行次數為 <c>O(|V|+|E|)</c>，其中 <c>G</c> 是一個有向無環圖。
+  /// 這意味著，即使軌格很大，也可以用很少的算力就可以爬軌。
+  /// </summary>
+  /// <returns>爬軌結果＋該過程是否順利執行。</returns>
+  private Tuple<WalkResult, bool> VertexWalk() {
+    WalkResult result = new(nodes: new(), vertices: 0, edges: 0);
+    if (Spans.Count == 0) {
+      UpdateWalkedAnchors(new());
+      return new(result, true);
+    }
+    List<List<Vertex>> vertexSpans = Spans
+                                         .Select(
+                                             _ => new List<Vertex>())
+                                         .ToList();
+
+    foreach (var neta in Spans.Select((span, i) => new { i, span })) {
+      for (int j = 1; j <= neta.span.MaxLength; j += 1) {
+        if (neta.span.NodeOf(j) is not {} p) continue;
+        vertexSpans[neta.i].Add(new(node: p));
+        result.Vertices += 1;
+      }
+    }
+
+    Vertex terminal = new(node: new(key: "_TERMINAL_"));
+
+    foreach (var ii in vertexSpans.Select((item, index) => new { index, item })) {
+      int i = ii.index;
+      List<Vertex> vertexSpan = ii.item;
+      foreach (Vertex vertex in vertexSpan) {
+        int nextVertexPosition = i + vertex.Node.SpanLength;
+        if (nextVertexPosition == vertexSpans.Count) {
+          vertex.Edges.Add(terminal);
+          continue;
+        }
+        foreach (Vertex nextVertex in vertexSpans[nextVertexPosition]) {
+          vertex.Edges.Add(nextVertex);
+          result.Edges += 1;
+        }
+      }
+    }
+
+    Vertex root = new(node: new(key: "_ROOT_")) { Distance = 0 };
+    root.Edges.AddRange(vertexSpans[0]);
+
+    List<Vertex> ordered = Vertex.TopologicalSort(root);
+
+    foreach (Vertex t in ordered) {
+      for (int k = 0; k < t.Edges.Count; k++) {
+        t.Edges[k] = Vertex.Relax(t, t.Edges[k]);
+      }
+    }
+
+    // 接下來這段處理可能有問題需要修正。
+    List<Node> walked = new();
+    int totalReadingLength = 0;
+    List<Vertex> orderedReversed = ordered;
+    orderedReversed.Reverse();
+    while (totalReadingLength < Readings.Count + 2 && orderedReversed[totalReadingLength].Edges.Last() is {} lastEdge) {
+      if (lastEdge.Prev is {} vertexPrev && !string.IsNullOrEmpty(vertexPrev.Node.CurrentPair.Value))
+        walked.Add(vertexPrev.Node);
+      else if (!string.IsNullOrEmpty(lastEdge.Node.CurrentPair.Value))
+        walked.Add(lastEdge.Node);
+      int oldTotalReadingLength = totalReadingLength;
+      totalReadingLength += lastEdge.Node.SpanLength;
+      if (oldTotalReadingLength == totalReadingLength) {
+        break;
+      }
+    }
+
+    if (totalReadingLength != Readings.Count) {
+      Console.WriteLine($"!!! Error A: readingLength: {totalReadingLength}, readingCount: {Readings.Count}");
+      UpdateWalkedAnchors(new());
+      return new(result, false);
+    }
+
+    result.Nodes = walked;
+    UpdateWalkedAnchors(result.Nodes);
+    return new(result, true);
+  }
+}
+}

--- a/Megrez/2_Grid.cs
+++ b/Megrez/2_Grid.cs
@@ -24,56 +24,70 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Megrez {
 /// <summary>
-/// 軌格。
+/// 軌格，會被組字器作為原始型別來繼承。
 /// </summary>
-public class Grid {
+public abstract class Grid {
+  /// <summary>
+  /// 軌格增減行為。
+  /// </summary>
+  public enum ResizeBehavior {
+    /// <summary>
+    /// 擴增。
+    /// </summary>
+    Expand,
+    /// <summary>
+    /// 縮減。
+    /// </summary>
+    Shrink
+  }
   /// <summary>
   /// 幅位陣列。
   /// </summary>
-  private List<Span> _spans = new();
+  public List<SpanUnit> Spans { get; private set; } = new();
   /// <summary>
   /// 初期化轨格。
   /// </summary>
-  /// <param name="spanLength">該軌格內可以允許的最大幅位長度。</param>
-  public Grid(int spanLength = 10) { MaxBuildSpanLength = spanLength; }
+  /// <param name="spanLengthLimit">該軌格內可以允許的最大幅位長度。</param>
+  public Grid(int spanLengthLimit = 10) { MaxBuildSpanLength = spanLengthLimit; }
   /// <summary>
-  /// 公開：該軌格內可以允許的最大幅位長度。
+  /// 公開：該組字器軌格內可以允許的最大幅位長度。
   /// </summary>
   public int MaxBuildSpanLength { get; }
   /// <summary>
   /// 公開：軌格的寬度，也就是其內的幅位陣列當中的幅位數量。
   /// </summary>
-  public int Width => _spans.Count;
+  public int Width => Spans.Count;
   /// <summary>
-  /// 公開：軌格是否為空。
+  /// 公開：該組字器軌格是否為空。
   /// </summary>
-  public bool IsEmpty => _spans.Count == 0;
+  public bool IsEmpty => Spans.Count == 0;
   /// <summary>
   /// 自我清空該軌格的內容。
   /// </summary>
-  public void Clear() { _spans.Clear(); }
+  public virtual void Clear() { Spans.Clear(); }
   /// <summary>
   /// 往該軌格的指定位置插入指定幅位長度的指定節點。
   /// </summary>
   /// <param name="node">節點。</param>
   /// <param name="location">位置。</param>
-  /// <param name="spanningLength">給定的幅位長度。</param>
-  public void InsertNode(Node node, int location, int spanningLength) {
+  /// <param name="spanLength">給定的幅位長度。</param>
+  public void InsertNode(Node node, int location, int spanLength) {
     location = Math.Abs(location);
-    spanningLength = Math.Abs(spanningLength);
-    if (location >= _spans.Count) {
-      int diff = location - _spans.Count + 1;
+    spanLength = Math.Abs(spanLength);
+    if (location >= Spans.Count) {
+      int diff = location - Spans.Count + 1;
       for (int I = 0; I < diff; I++) {
-        _spans.Add(new());
+        Spans.Add(new());
       }
     }
-    Span spanToDealWith = _spans[location];
-    spanToDealWith.Insert(node, spanningLength);
-    _spans[location] = spanToDealWith;
+    SpanUnit spanToDealWith = Spans[location];
+    spanToDealWith.Insert(node, spanLength);
+    Spans[location] = spanToDealWith;
   }
   /// <summary>
   /// 給定索引鍵、位置、幅位長度，在該軌格內確認是否有對應的節點存在。
@@ -85,40 +99,37 @@ public class Grid {
   public bool HasMatchedNode(int location, int spanningLength, string key) {
     int theLocation = Math.Abs(location);
     int theSpanningLength = Math.Abs(spanningLength);
-    if (theLocation > _spans.Count) {
+    if (theLocation > Spans.Count) {
       return false;
     }
-    Node? n = _spans[theLocation].Node(theSpanningLength);
+    Node? n = Spans[theLocation].NodeOf(theSpanningLength);
     return n != null && key == n.Key;
   }
   /// <summary>
-  /// 在該軌格的指定位置擴增一個幅位。
+  /// 在該軌格的指定位置擴增或減少一個幅位。
   /// </summary>
   /// <param name="location">位置。</param>
-  public void ExpandGridByOneAt(int location) {
-    int theLocation = Math.Abs(location);
-    _spans.Insert(theLocation, new());
-    if (theLocation == 0 || theLocation == _spans.Count) return;
-    for (int I = 0; I < theLocation; I++) {
-      Span theSpan = _spans[I];
-      theSpan.RemoveNodeOfLengthGreaterThan(theLocation - I);
-      _spans[I] = theSpan;
+  /// <param name="behavior">決定是新增還是減少一個幅位。</param>
+  public void ResizeGridByOneAt(int location, ResizeBehavior behavior) {
+    location = Math.Max(0, Math.Min(Width, location));
+    switch (behavior) {
+      case ResizeBehavior.Expand:
+        Spans.Insert(location, new());
+        if (location == 0 || location == Spans.Count) return;
+        break;
+      case ResizeBehavior.Shrink:
+        if (location >= Spans.Count) return;
+        Spans.RemoveAt(location);
+        break;
+    }
+    for (int i = 0; i < location; i++) {
+      // 處理掉被損毀的或者重複的幅位。
+      SpanUnit theSpan = Spans[i];
+      theSpan.DropNodesBeyond(location - i);
+      Spans[i] = theSpan;
     }
   }
-  /// <summary>
-  /// 在該軌格的指定位置減少一個幅位。
-  /// </summary>
-  /// <param name="location">位置。</param>
-  public void ShrinkGridByOneAt(int location) {
-    location = Math.Abs(location);
-    if (location >= _spans.Count) return;
-    _spans.RemoveAt(location);
-    for (int I = 0; I < location; I++) {
-      Span theSpan = _spans[I];
-      theSpan.RemoveNodeOfLengthGreaterThan(location - I);
-      _spans[I] = theSpan;
-    }
-  }
+
   /// <summary>
   /// 給定位置，枚舉出所有在這個位置開始的節點。
   /// </summary>
@@ -127,11 +138,11 @@ public class Grid {
   public List<NodeAnchor> NodesBeginningAt(int location) {
     int theLocation = Math.Abs(location);
     List<NodeAnchor> results = new();
-    if (theLocation >= _spans.Count) return results;  // 此時 MutSpans 必定不為空
-    Span span = _spans[theLocation];
+    if (theLocation >= Spans.Count) return results;  // 此時 MutSpans 必定不為空
+    SpanUnit span = Spans[theLocation];
     for (int I = 1; I <= MaxBuildSpanLength; I++) {
-      Node? np = span.Node(I);
-      if (np != null) results.Add(new(np, theLocation, I));
+      Node? np = span.NodeOf(I);
+      if (np != null) results.Add(new(np));
     }
     return results;
   }
@@ -143,12 +154,12 @@ public class Grid {
   public List<NodeAnchor> NodesEndingAt(int location) {
     int theLocation = Math.Abs(location);
     List<NodeAnchor> results = new();
-    if (_spans.Count == 0 || theLocation > _spans.Count) return results;
+    if (Spans.Count == 0 || theLocation > Spans.Count) return results;
     for (int I = 0; I < theLocation; I++) {
-      Span span = _spans[I];
-      if (I + span.MaximumLength < theLocation) continue;
-      Node? np = span.Node(theLocation - I);
-      if (np != null) results.Add(new(np, I, theLocation - I));
+      SpanUnit span = Spans[I];
+      if (I + span.MaxLength < theLocation) continue;
+      Node? np = span.NodeOf(theLocation - I);
+      if (np != null) results.Add(new(np));
     }
     return results;
   }
@@ -160,17 +171,28 @@ public class Grid {
   public List<NodeAnchor> NodesCrossingOrEndingAt(int location) {
     int theLocation = Math.Abs(location);
     List<NodeAnchor> results = new();
-    if (_spans.Count == 0 || theLocation > _spans.Count) return results;
+    if (Spans.Count == 0 || theLocation > Spans.Count) return results;
     for (int I = 0; I < theLocation; I++) {
-      Span span = _spans[I];
-      if (I + span.MaximumLength < theLocation) continue;
-      for (int j = 1; j <= span.MaximumLength; j++) {
+      SpanUnit span = Spans[I];
+      if (I + span.MaxLength < theLocation) continue;
+      for (int j = 1; j <= span.MaxLength; j++) {
         if (I + j < location) continue;
-        Node? np = span.Node(j);
-        if (np != null) results.Add(new(np, I, theLocation - I));
+        Node? np = span.NodeOf(j);
+        if (np != null) results.Add(new(np));
       }
     }
     return results;
+  }
+  /// <summary>
+  /// 給定位置，枚舉出所有在這個位置結尾或開頭或者橫跨該位置的節點。<br />
+  /// ⚠︎ 注意：排序可能失真。
+  /// </summary>
+  /// <param name="location">位置。</param>
+  /// <returns>均有節點的節錨陣列。</returns>
+  public List<NodeAnchor> NodesOverlappedAt(int location) {
+    List<NodeAnchor> x = NodesBeginningAt(location);
+    x.AddRange(NodesCrossingOrEndingAt(location));
+    return x.Distinct().ToList();
   }
   /// <summary>
   /// 將給定位置的節點的候選字詞改為與給定的字串一致的候選字詞。該函式可以僅用作過程函式。
@@ -178,18 +200,43 @@ public class Grid {
   /// <param name="location">位置。</param>
   /// <param name="value">給定字串。</param>
   /// <returns>一個節錨，內容可能為空。該結果僅用作偵錯用途。</returns>
-  public NodeAnchor FixNodeSelectedCandidate(int location, string value) {
+  public NodeAnchor FixNodeWithCandidateLiteral(string value, int location) {
     int theLocation = Math.Abs(location);
     NodeAnchor node = new();
     foreach (NodeAnchor nodeAnchor in NodesCrossingOrEndingAt(theLocation)) {
-      Node? theNode = nodeAnchor.Node;
-      if (theNode == null) continue;
+      Node theNode = nodeAnchor.Node;
       List<KeyValuePaired> candidates = theNode.Candidates;
       // 將該位置的所有節點的候選字詞鎖定狀態全部重設。
       theNode.ResetCandidate();
       int I = 0;
       foreach (KeyValuePaired candidate in candidates) {
         if (candidate.Value == value) {
+          theNode.SelectCandidateAt(I);
+          node = nodeAnchor;
+          break;
+        }
+        I += 1;
+      }
+    }
+    return node;
+  }
+  /// <summary>
+  /// 將給定位置的節點的候選字詞改為與給定的字串一致的候選字詞。該函式可以僅用作過程函式。
+  /// </summary>
+  /// <param name="location">位置。</param>
+  /// <param name="value">給定字串。</param>
+  /// <returns>一個節錨，內容可能為空。該結果僅用作偵錯用途。</returns>
+  public NodeAnchor FixNodeWithCandidate(KeyValuePaired value, int location) {
+    int theLocation = Math.Abs(location);
+    NodeAnchor node = new();
+    foreach (NodeAnchor nodeAnchor in NodesCrossingOrEndingAt(theLocation)) {
+      Node theNode = nodeAnchor.Node;
+      List<KeyValuePaired> candidates = theNode.Candidates;
+      // 將該位置的所有節點的候選字詞鎖定狀態全部重設。
+      theNode.ResetCandidate();
+      int I = 0;
+      foreach (KeyValuePaired candidate in candidates) {
+        if (candidate == value) {
           theNode.SelectCandidateAt(I);
           node = nodeAnchor;
           break;
@@ -208,8 +255,7 @@ public class Grid {
   public void OverrideNodeScoreForSelectedCandidate(int location, string value, double overridingScore) {
     int theLocation = Math.Abs(location);
     foreach (NodeAnchor nodeAnchor in NodesCrossingOrEndingAt(theLocation)) {
-      Node? theNode = nodeAnchor.Node;
-      if (theNode == null) continue;
+      Node theNode = nodeAnchor.Node;
       List<KeyValuePaired> candidates = theNode.Candidates;
       // 將該位置的所有節點的候選字詞鎖定狀態全部重設。
       theNode.ResetCandidate();
@@ -229,22 +275,22 @@ public class Grid {
   /// <returns>GraphViz 檔案內容，純文字。</returns>
   public string DumpDOT() {
     string strOutput = "digraph {\ngraph [ rankdir=LR ];\nBOS;\n";
-    for (int p = 0; p < _spans.Count; p++) {
-      Span span = _spans[p];
-      for (int ni = 0; ni <= span.MaximumLength; ni++) {
-        if (span.Node(ni) == null) continue;
-        Node np = span.Node(ni) ?? new("", new());
-        if (p == 0) strOutput += "BOS -> " + np.CurrentKeyValue.Value + ";\n";
-        strOutput += np.CurrentKeyValue.Value + ";\n";
-        if (p + ni < _spans.Count) {
-          Span destinationSpan = _spans[p + ni];
-          for (int q = 0; q <= destinationSpan.MaximumLength; q++) {
-            if (destinationSpan.Node(q) == null) continue;
-            Node dn = destinationSpan.Node(q) ?? new("", new());
-            strOutput += np.CurrentKeyValue.Value + " -> " + dn.CurrentKeyValue.Value + ";\n";
+    for (int p = 0; p < Spans.Count; p++) {
+      SpanUnit span = Spans[p];
+      for (int ni = 0; ni <= span.MaxLength; ni++) {
+        if (span.NodeOf(ni) == null) continue;
+        Node np = span.NodeOf(ni) ?? new();
+        if (p == 0) strOutput += "BOS -> " + np.CurrentPair.Value + ";\n";
+        strOutput += np.CurrentPair.Value + ";\n";
+        if (p + ni < Spans.Count) {
+          SpanUnit destinationSpan = Spans[p + ni];
+          for (int q = 0; q <= destinationSpan.MaxLength; q++) {
+            if (destinationSpan.NodeOf(q) == null) continue;
+            Node dn = destinationSpan.NodeOf(q) ?? new();
+            strOutput += np.CurrentPair.Value + " -> " + dn.CurrentPair.Value + ";\n";
           }
         }
-        if (p + ni == _spans.Count) strOutput += np.CurrentKeyValue.Value + " -> EOS;\n";
+        if (p + ni == Spans.Count) strOutput += np.CurrentPair.Value + " -> EOS;\n";
       }
     }
     strOutput += "EOS;\n}\n";

--- a/Megrez/3_NodeAnchor.cs
+++ b/Megrez/3_NodeAnchor.cs
@@ -23,6 +23,9 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Megrez {
 /// <summary>
 /// 節锚。
@@ -31,45 +34,74 @@ public struct NodeAnchor {
   /// <summary>
   /// 節锚。
   /// </summary>
-  public NodeAnchor(Node node, int location, int spanningLength) {
+  public NodeAnchor(Node node, double? mass = null) {
     Node = node;
-    Location = location;
-    SpanningLength = spanningLength;
+    Mass = mass ?? Node.Score;
   }
+  /// <summary>
+  /// 用來判斷該節錨是否為空。
+  /// </summary>
+  public bool IsEmpty => string.IsNullOrEmpty(Node.Key);
   /// <summary>
   /// 節點。一個節锚內不一定有節點，還可能會出 null。
   /// </summary>
-  public Node? Node = null;
-  /// <summary>
-  /// 節锚所在的位置。
-  /// </summary>
-  public int Location = 0;
-  /// <summary>
-  /// 幅位長度。
-  /// </summary>
-  public int SpanningLength = 0;
-  /// <summary>
-  /// 累計權重。
-  /// </summary>
-  public double AccumulatedScore = 0.0;
-  /// <summary>
-  /// 索引鍵的長度。
-  /// </summary>
-  public int KeyLength => Node?.Key.Length ?? 0;
+  public Node Node = new();
   /// <summary>
   /// 獲取用來比較的權重。
   /// </summary>
-  public double ScoreForSort => Node?.Score ?? 0.0;
+  public double ScoreForSort => Node.Score;
+  /// <summary>
+  /// 幅位長度。
+  /// </summary>
+  public int SpanLength => Node.SpanLength;
+  /// <summary>
+  /// 累計權重。
+  /// </summary>
+  public double Mass = 0.0;
+  /// <summary>
+  /// 索引鍵。
+  /// </summary>
+  public string Key => Node.Key;
+  /// <summary>
+  /// 單元圖陣列。
+  /// </summary>
+  public List<Unigram> Unigrams => Node.Unigrams;
+  /// <summary>
+  /// 雙元圖陣列。
+  /// </summary>
+  public List<Bigram> Bigrams => Node.Bigrams;
   /// <summary>
   /// 將當前節錨的內容輸出為字串。
   /// </summary>
   /// <returns>當前節錨的內容輸出成的字串。</returns>
   public override string ToString() {
     string stream = "";
-    stream += "{@(" + Location + "," + SpanningLength + "),";
+    stream += "{@(" + SpanLength + "),";
     stream += Node != null ? Node.ToString() : "null";
     stream += "}";
     return stream;
   }
 }
+/// <summary>
+/// 用以在陣列內容為節錨的時候擴展陣列功能。
+/// </summary>
+public static class NodeAnchorExtensions {
+  /// <summary>
+  /// 獲取當前節錨陣列當中的索引鍵陣列。
+  /// </summary>
+  /// <param name="list">資料來源陣列。</param>
+  /// <returns>得到的索引鍵陣列。</returns>
+  public static string[] Keys(this IEnumerable<NodeAnchor> list) {
+    return list.Select(x => x.Node.CurrentPair.Key).ToArray();
+  }
+  /// <summary>
+  /// 獲取當前節錨陣列當中的資料值陣列。
+  /// </summary>
+  /// <param name="list">資料來源陣列。</param>
+  /// <returns>得到的資料值陣列。</returns>
+  public static string[] Values(this IEnumerable<NodeAnchor> list) {
+    return list.Select(x => x.Node.CurrentPair.Value).ToArray();
+  }
+}
+
 }

--- a/Megrez/3_Span.cs
+++ b/Megrez/3_Span.cs
@@ -30,11 +30,11 @@ namespace Megrez {
 /// <summary>
 /// 幅位。
 /// </summary>
-public struct Span {
+public struct SpanUnit {
   /// <summary>
   /// 幅位。
   /// </summary>
-  public Span() {}
+  public SpanUnit() {}
   /// <summary>
   /// 辭典：以節點長度為索引，以節點為資料值。
   /// </summary>
@@ -42,13 +42,13 @@ public struct Span {
   /// <summary>
   /// 公開：最長幅距（唯讀）。
   /// </summary>
-  public int MaximumLength { get; private set; } = 0;
+  public int MaxLength { get; private set; } = 0;
   /// <summary>
   /// 自我清空，各項參數歸零。
   /// </summary>
   public void Clear() {
     _lengthNodeMap.Clear();
-    MaximumLength = 0;
+    MaxLength = 0;
   }
   /// <summary>
   /// 往自身插入一個節點、及給定的節點長度。
@@ -58,15 +58,15 @@ public struct Span {
   public void Insert(Node node, int length) {
     length = Math.Abs(length);
     _lengthNodeMap[length] = node;
-    MaximumLength = Math.Max(MaximumLength, length);
+    MaxLength = Math.Max(MaxLength, length);
   }
   /// <summary>
   /// 移除任何比給定的長度更長的節點。
   /// </summary>
   /// <param name="length">給定的節點長度。</param>
-  public void RemoveNodeOfLengthGreaterThan(int length) {
+  public void DropNodesBeyond(int length) {
     length = Math.Abs(length);
-    if (length > MaximumLength) return;
+    if (length > MaxLength) return;
     int lenMax = 0;
     Dictionary<int, Node> removalList = new();
     foreach (int key in _lengthNodeMap.Keys) {
@@ -78,14 +78,14 @@ public struct Span {
     foreach (int key in removalList.Keys) {
       _lengthNodeMap.Remove(key);
     }
-    MaximumLength = lenMax;
+    MaxLength = lenMax;
   }
   /// <summary>
   /// 給定節點長度，獲取節點。
   /// </summary>
   /// <param name="length">給定的節點長度。</param>
   /// <returns>節點。如果沒有節點則傳回 null。</returns>
-  public Node? Node(int length) {
+  public Node? NodeOf(int length) {
     return _lengthNodeMap.ContainsKey(Math.Abs(length)) ? _lengthNodeMap[Math.Abs(length)] : null;
   }
 }

--- a/Megrez/4_Node.cs
+++ b/Megrez/4_Node.cs
@@ -35,11 +35,11 @@ public class Node {
   /// <summary>
   /// 單元圖陣列。
   /// </summary>
-  private List<Unigram> _unigrams;
+  public List<Unigram> Unigrams { get; private set; }
   /// <summary>
   /// 雙元圖陣列。
   /// </summary>
-  private List<Bigram> _bigrams;
+  public List<Bigram> Bigrams { get; private set; }
   /// <summary>
   /// 專門「用單元圖資料值來調查索引值」的辭典。
   /// </summary>
@@ -52,6 +52,10 @@ public class Node {
   /// 用來登記「當前選中的單元圖」的索引值的變數。
   /// </summary>
   private int _selectedUnigramIndex;
+  /// <summary>
+  /// 指定的幅位長度。
+  /// </summary>
+  public int SpanLength { get; private set; }
 
   /// <summary>
   /// 用來登記要施加給「『被標記為選中狀態』的候選字詞」的複寫權重的數值。
@@ -62,7 +66,7 @@ public class Node {
   /// </summary>
   /// <returns>當前節點的內容輸出成的字串。</returns>
   public override string ToString() =>
-      $"(node,key:{Key},fixed:{(IsCandidateFixed ? "true" : "false")},selected:{_selectedUnigramIndex},{_unigrams})";
+      $"(node,key:{Key},fixed:{(IsCandidateFixed ? "true" : "false")},selected:{_selectedUnigramIndex},{Unigrams})";
   /// <summary>
   /// 公開：候選字詞陣列（唯讀），以鍵值陣列的形式存在。
   /// </summary>
@@ -74,7 +78,7 @@ public class Node {
   /// <summary>
   /// 公開：鍵（唯讀）。
   /// </summary>
-  public string Key { get; } = "";
+  public string Key { get; private set; } = "";
   /// <summary>
   /// 公開：當前節點的當前被選中的候選字詞「在該節點內的」目前的權重（唯讀）。
   /// </summary>
@@ -82,32 +86,34 @@ public class Node {
   /// <summary>
   /// 公開：當前被選中的候選字詞的鍵值配對。
   /// </summary>
-  public KeyValuePaired CurrentKeyValue =>
-      _selectedUnigramIndex >= _unigrams.Count ? new() : Candidates[_selectedUnigramIndex];
+  public KeyValuePaired CurrentPair =>
+      _selectedUnigramIndex >= Unigrams.Count ? new() : Candidates[_selectedUnigramIndex];
   /// <summary>
   /// 公開：給出當前單元圖陣列內最高的權重數值。
   /// </summary>
-  public double HighestUnigramScore => _unigrams.Count == 0 ? 0.0 : _unigrams.FirstOrDefault().Score;
+  public double HighestUnigramScore => Unigrams.Count == 0 ? 0.0 : Unigrams.FirstOrDefault().Score;
 
   /// <summary>
   /// 初期化一個節點。
   /// </summary>
   /// <param name="key">索引鍵。</param>
+  /// <param name="spanLength">幅位長度。</param>
   /// <param name="unigrams">單元圖陣列。</param>
   /// <param name="bigrams">雙元圖陣列（非必填）。</param>
-  public Node(string key, List<Unigram> unigrams, List<Bigram>? bigrams = null) {
+  public Node(string key = "", int spanLength = 0, List<Unigram>? unigrams = null, List<Bigram>? bigrams = null) {
     Key = key;
-    _unigrams = unigrams;
-    _bigrams = bigrams ?? new();
-    _unigrams.Sort((a, b) => b.Score.CompareTo(a.Score));
+    Unigrams = unigrams ?? new();
+    Bigrams = bigrams ?? new();
+    SpanLength = spanLength;
+    Unigrams.Sort((a, b) => b.Score.CompareTo(a.Score));
     _valueUnigramIndexMap = new();
-    if (_unigrams.Count > 0) Score = _unigrams[0].Score;
-    for (int I = 0; I < _unigrams.Count; I++) {
-      Unigram gram = _unigrams[I];
+    if (Unigrams.Count > 0) Score = Unigrams[0].Score;
+    for (int I = 0; I < Unigrams.Count; I++) {
+      Unigram gram = Unigrams[I];
       _valueUnigramIndexMap[gram.KeyValue.Value] = I;
       Candidates.Add(gram.KeyValue);
     }
-    foreach (Bigram gram in _bigrams.Where(gram => _precedingBigramMap.ContainsKey(gram.KeyValuePreceded))) {
+    foreach (Bigram gram in Bigrams.Where(gram => _precedingBigramMap.ContainsKey(gram.KeyValuePreceded))) {
       _precedingBigramMap[gram.KeyValuePreceded].Add(gram);
     }
   }
@@ -138,7 +144,7 @@ public class Node {
   /// <param name="index">索引位置。</param>
   /// <param name="fix">是否將當前解點標記為「候選詞已鎖定」的狀態。</param>
   public void SelectCandidateAt(int index = 0, bool fix = false) {
-    _selectedUnigramIndex = index >= _unigrams.Count ? 0 : index;
+    _selectedUnigramIndex = index >= Unigrams.Count ? 0 : index;
     IsCandidateFixed = fix;
     Score = ConSelectedCandidateScore;
   }
@@ -148,7 +154,7 @@ public class Node {
   public void ResetCandidate() {
     _selectedUnigramIndex = 0;
     IsCandidateFixed = false;
-    if (_unigrams.Count != 0) Score = _unigrams.FirstOrDefault().Score;
+    if (Unigrams.Count != 0) Score = Unigrams.FirstOrDefault().Score;
   }
   /// <summary>
   /// 選中位於給定索引位置的候選字詞、且施加給定的權重。
@@ -157,7 +163,7 @@ public class Node {
   /// <param name="score">給定權重條件。</param>
   public void SelectFloatingCandidateAt(int index, double score) {
     int realIndex = Math.Abs(index);
-    _selectedUnigramIndex = realIndex >= _unigrams.Count ? 0 : realIndex;
+    _selectedUnigramIndex = realIndex >= Unigrams.Count ? 0 : realIndex;
     IsCandidateFixed = false;
     Score = score;
   }
@@ -168,8 +174,20 @@ public class Node {
   /// <returns>在庫的單元圖權重數值；沒有在庫的話就找零。</returns>
   public double ScoreFor(string candidate) {
     double result = 0.0;
-    foreach (Unigram unigram in _unigrams.Where(unigram => unigram.KeyValue.Value == candidate)) {
-      result = unigram.Score;
+    foreach (Unigram unigram in Unigrams.Where(unigram => unigram.KeyValue.Value == candidate)) {
+      return unigram.Score;
+    }
+    return result;
+  }
+  /// <summary>
+  /// 藉由給定的候選字詞鍵值配對，找出在庫的單元圖權重數值。沒有的話就找零。
+  /// </summary>
+  /// <param name="candidate">給定的候選字詞字串。</param>
+  /// <returns>在庫的單元圖權重數值；沒有在庫的話就找零。</returns>
+  public double ScoreForPaired(KeyValuePaired candidate) {
+    double result = 0.0;
+    foreach (Unigram unigram in Unigrams.Where(unigram => unigram.KeyValue == candidate)) {
+      return unigram.Score;
     }
     return result;
   }
@@ -179,7 +197,7 @@ public class Node {
   /// <param name="obj">用來比較的節點。</param>
   /// <returns>若相等，則返回 true。</returns>
   public override bool Equals(object obj) {
-    return obj is Node node && EqualityComparer<List<Unigram>>.Default.Equals(_unigrams, node._unigrams) &&
+    return obj is Node node && EqualityComparer<List<Unigram>>.Default.Equals(Unigrams, node.Unigrams) &&
            EqualityComparer<List<KeyValuePaired>>.Default.Equals(Candidates, node.Candidates) &&
            EqualityComparer<Dictionary<string, int>>.Default.Equals(_valueUnigramIndexMap,
                                                                     node._valueUnigramIndexMap) &&
@@ -193,7 +211,11 @@ public class Node {
   /// </summary>
   /// <returns>當前節錨的內容輸出成的雜湊資料。</returns>
   public override int GetHashCode() {
-    unchecked { return (int)BitConverter.ToInt64(Convert.FromBase64String(ToString()), 0); }
+    int a1 = HashCode.Combine(Key, Score, Unigrams, Bigrams);
+    int a2 = HashCode.Combine(_precedingBigramMap, SpanLength, Candidates, _valueUnigramIndexMap);
+    int a3 = HashCode.Combine(_precedingBigramMap, IsCandidateFixed, _selectedUnigramIndex);
+    string combined = a1.ToString() + a2.ToString() + a3.ToString();
+    return HashCode.Combine(combined);
   }
 }
 }

--- a/Megrez/5_LanguageModel.cs
+++ b/Megrez/5_LanguageModel.cs
@@ -24,13 +24,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Megrez {
 /// <summary>
 /// 語言模型框架協定，實際使用時需要派生一個型別、且重寫相關函式。
 /// </summary>
-public interface LanguageModel {
+public interface LangModelProtocol {
   /// <summary>
   /// 給定鍵，讓語言模型找給一組單元圖陣列。
   /// </summary>
@@ -44,7 +43,7 @@ public interface LanguageModel {
   /// <param name="precedingKey">前述鍵。</param>
   /// <param name="key">當前鍵。</param>
   /// <returns>一組雙元圖陣列。</returns>
-  public List<Bigram> BigramsForKeys(string precedingKey, string key);
+  public List<Bigram> BigramsFor(string precedingKey, string key);
 
   /// <summary>
   /// 給定鍵，確認是否有單元圖記錄在庫。

--- a/Megrez/Megrez.csproj
+++ b/Megrez/Megrez.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <ReleaseVersion>1.2.8</ReleaseVersion>
+    <ReleaseVersion>1.2.9</ReleaseVersion>
     <PackageId>vChewing.Megrez</PackageId>
     <Authors>Shiki Suen</Authors>
     <Company>Atelier Inmu</Company>
     <Copyright>(c) 2022 and onwards The vChewing Project (MIT-NTL License).</Copyright>
     <RepositoryUrl>https://github.com/ShikiSuen/MegrezNT</RepositoryUrl>
     <NeutralLanguage>zh-TW</NeutralLanguage>
-    <AssemblyVersion>1.2.8</AssemblyVersion>
-    <FileVersion>1.2.8</FileVersion>
-    <Version>1.2.8</Version>
+    <AssemblyVersion>1.2.9</AssemblyVersion>
+    <FileVersion>1.2.9</FileVersion>
+    <Version>1.2.9</Version>
     <Product>Megrez</Product>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
本次 v1.2.9 維護更新主要修改這幾點：

1. 符號命名體系有所更動。
2. 將 Compositor 與 Grid 整合：前者直接繼承後者。
3. 因為實際使用當中 NodeAnchor 的 Node 一定不會是 nil，所以直接去掉了這個變數的 nil 能力。這樣可以（同時在模組內與模組外）節省海量的 guard-let / if-let 判定。
4. 對 walk() 做了簡化：將 reverseWalk() 作為內部處理隱藏起來，且讓對外的 walk() 無須傳入任何參數。
5. 讓 fixNode **僅針對指定讀音**來執行手動選字操作。
6. 豐富單元測試的內容。
7. NodeAnchor 及 Node 這兩種型別現可雜湊化。此外，NodeAnchor 結構進一步縮減，相關參數除了 mass 以外全部下放給 node。這樣一來，初期化一個 NodeAnchor 只需要 node 本體即可、且可以在想指定 mass 的時候指定之。至於 mass 這個參數不能下放給 node 來管理，是有原因的：一旦下放了，會影響選字、使得多字組成的詞必須得有相當高的權重數值才會被 walk() 自動選中。
8. 允許以鍵值配對為對象來查詢其權重數值。
9. 允許以幅位為單位來移動游標。
10. 嘗試從上游引入基於頂點算法的爬軌函式 fastWalk()。相關內容集中在「1_VertexWalker.swift」內，不受其它檔案所依賴。單元測試內有少數內容用來測試該函式的基礎功能。然而，這個函式的引入方法有些問題，導致其無法始終反應手動選字結果。在 C++ 當中可行的相同做法（特別是指針弄巧），在 Swift / C# 這種中高層語言當中必須另闢蹊徑。於是，這個函式目前屬於雪藏狀態。由於該函數的實際運作機理超出了本人的學歷學識學力範疇（我是學音樂的），所以只能另找專人來檢查「可以使其恢復運作」的可行性。

P.S.: 本次特意有測試是否可以將 NodeAnchor 與 Node 整合在一起。然而這樣一來的話會導致手動選字功能失效，所以只能作罷。NodeAnchor 這個結構型別獨立而生所帶來的唯一便利，恐怕就是為了讓裡面的 Node 對自身的函數操作生效。