### PR TITLE
Fix mistakes in checking the equality of two arrays.

### DIFF
--- a/Megrez.Tests/LMDataForTests.cs
+++ b/Megrez.Tests/LMDataForTests.cs
@@ -32,7 +32,7 @@ public class SimpleLM : LangModelProtocol {
         }
         Unigram u = new(value);
         u.Score = col2;
-        if (!_database.ContainsKey(key)) _database.Add(key, new List<Unigram>());
+        if (!_database.ContainsKey(key)) _database.Add(key, new());
         _database[key].Add(u);
       }
     }
@@ -45,14 +45,17 @@ public class SimpleLM : LangModelProtocol {
     if (!_database.TryGetValue(key, out List<Unigram>? arr)) return;
     if (arr is not {} theArr) return;
     theArr = theArr.Where(x => x.Value != value).ToList();
-    if (theArr.IsEmpty()) return;
+    if (theArr.IsEmpty()) {
+      _database.Remove(key);
+      return;
+    }
     _database[key] = theArr;
   }
 }
 
 public class MockLM : LangModelProtocol {
   public bool HasUnigramsFor(List<string> keyArray) => !IsNullOrEmpty(keyArray.Joined());
-  public List<Unigram> UnigramsFor(List<string> keyArray) => new() { new Unigram(value: keyArray.Joined(), score: -1) };
+  public List<Unigram> UnigramsFor(List<string> keyArray) => new() { new(value: keyArray.Joined(), score: -1) };
 }
 
 public class TestLM : LangModelProtocol {

--- a/Megrez/src/0_CSharpExtensions.cs
+++ b/Megrez/src/0_CSharpExtensions.cs
@@ -59,13 +59,13 @@ public static class CSharpExtensions {
 
   public static void StableSort<T>(this T[] values, Comparison<T> comparison) {
     KeyValuePair<int, T>[] keys = new KeyValuePair<int, T>[values.Length];
-    for (int i = 0; i < values.Length; i++) keys[i] = new KeyValuePair<int, T>(i, values[i]);
+    for (int i = 0; i < values.Length; i++) keys[i] = new(i, values[i]);
     Array.Sort(keys, values, new StabilizingComparer<T>(comparison));
   }
 
   public static List<T> StableSorted<T>(this List<T> values, Comparison<T> comparison) {
     KeyValuePair<int, T>[] keys = new KeyValuePair<int, T>[values.Count()];
-    for (int i = 0; i < values.Count(); i++) keys[i] = new KeyValuePair<int, T>(i, values[i]);
+    for (int i = 0; i < values.Count(); i++) keys[i] = new(i, values[i]);
     T[] theValues = values.ToArray();
     Array.Sort(keys, theValues, new StabilizingComparer<T>(comparison));
     return theValues.ToList();

--- a/Megrez/src/3_KeyValuePaired.cs
+++ b/Megrez/src/3_KeyValuePaired.cs
@@ -58,7 +58,7 @@ public partial struct Compositor {
     /// <param name="obj"></param>
     /// <returns></returns>
     public override bool Equals(object obj) {
-      return obj is KeyValuePaired pair && JoinedKey() == pair.JoinedKey() && Value == pair.Value;
+      return obj is KeyValuePaired pair && JoinedKey().SequenceEqual(pair.JoinedKey()) && Value == pair.Value;
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public partial struct Compositor {
     /// <param name="rhs"></param>
     /// <returns></returns>
     public static bool operator ==(KeyValuePaired lhs, KeyValuePaired rhs) {
-      return lhs.KeyArray.Count == rhs.KeyArray.Count && lhs.Value == rhs.Value;
+      return lhs.KeyArray.SequenceEqual(rhs.KeyArray) && lhs.Value == rhs.Value;
     }
     /// <summary>
     ///

--- a/Megrez/src/4_SpanUnit.cs
+++ b/Megrez/src/4_SpanUnit.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Megrez {
 public partial struct Compositor {
@@ -61,12 +62,16 @@ public partial struct Compositor {
     /// <returns>該操作是否成功執行。</returns>
     public bool DropNodesOfOrBeyond(int length) {
       if (!AllowedLengths.Contains(length)) return false;
-      foreach ((_, int i) in new BRange(length, MaxSpanLength + 1).Enumerated()) Nodes[i - 1] = null;
+      foreach (int i in new BRange(length, MaxSpanLength + 1)) {
+        if (i > Nodes.Count) continue;  // 防呆
+        Nodes[i - 1] = null;
+      }
       MaxLength = 0;
       if (length <= 1) return false;
       int maxR = length - 2;
       foreach (int i in new BRange(0, maxR + 1)) {
-        if (Nodes.Count < maxR) continue;
+        BRange countRange = new(0, maxR - i + 1);
+        if (!countRange.Contains(maxR - i)) continue;  // 防呆
         MaxLength = maxR - i + 1;
         break;
       }

--- a/Megrez/src/5_Vertex.cs
+++ b/Megrez/src/5_Vertex.cs
@@ -52,7 +52,7 @@ public partial struct Compositor {
       Prev = null;
       Edges.ForEach(delegate(Vertex edge) { edge.Destroy(); });
       Edges.Clear();
-      Node = new(keyArray: new List<string>(), unigrams: new List<Unigram>(), spanLength: 0);
+      Node = new(keyArray: new(), unigrams: new(), spanLength: 0);
     }
   }
 

--- a/Megrez/src/6_Node.cs
+++ b/Megrez/src/6_Node.cs
@@ -110,8 +110,9 @@ public partial struct Compositor {
     /// </summary>
     /// <param name="obj"></param>
     /// <returns></returns>
-    public override bool Equals(object obj) => obj is Node node && KeyArray == node.KeyArray
-                                               && SpanLength == node.SpanLength && Unigrams == node.Unigrams
+    public override bool Equals(object obj) => obj is Node node
+                                               && KeyArray.SequenceEqual(node.KeyArray) && SpanLength == node.SpanLength
+                                               && Unigrams == node.Unigrams
                                                && CurrentOverrideType == node.CurrentOverrideType;
 
     /// <summary>

--- a/Megrez/src/7_LangModel.cs
+++ b/Megrez/src/7_LangModel.cs
@@ -37,7 +37,7 @@ public partial struct Compositor {
     /// 一個專門用來與其它語言模型對接的外皮模組層，將所有獲取到的資料自動做固定排序處理。
     /// </summary>
     /// <param name="langModel">要對接的語言模型副本。</param>
-    public LangModelRanked(LangModelProtocol langModel) { TheLangModel = langModel; }
+    public LangModelRanked(ref LangModelProtocol langModel) { TheLangModel = langModel; }
     /// <summary>
     /// 給定索引鍵陣列，讓語言模型找給一組經過穩定排序的單元圖陣列。
     /// </summary>


### PR DESCRIPTION
* Looks like we cannot use `==` to compare two lists of Strings. We must use `A.SequenceEqual(B)` instead. Similar issues in Node and KeyValuePaired are also fixed in this commit.