### PR TITLE
Add a safety check in Compositor.Update().

### DIFF
--- a/Megrez.Tests/Megrez.Tests.csproj
+++ b/Megrez.Tests/Megrez.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>2.7.1</ReleaseVersion>
+    <ReleaseVersion>2.7.2</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Megrez.sln
+++ b/Megrez.sln
@@ -52,6 +52,6 @@ Global
 		$0.DotNetNamingPolicy = $4
 		$4.DirectoryNamespaceAssociation = PrefixedHierarchical
 		$0.StandardHeader = $5
-		version = 2.7.1
+		version = 2.7.2
 	EndGlobalSection
 EndGlobal

--- a/Megrez/Megrez.csproj
+++ b/Megrez/Megrez.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <ReleaseVersion>2.7.1</ReleaseVersion>
+    <ReleaseVersion>2.7.2</ReleaseVersion>
     <PackageId>vChewing.Megrez</PackageId>
     <Authors>Shiki Suen</Authors>
     <Company>Atelier Inmu</Company>
     <Copyright>(c) 2022 and onwards The vChewing Project for Megrez-specific changes; (c) 2022 and onwards Lukhnos Liu for upstream contents.</Copyright>
     <RepositoryUrl>https://github.com/ShikiSuen/MegrezNT</RepositoryUrl>
     <NeutralLanguage>zh-TW</NeutralLanguage>
-    <AssemblyVersion>2.7.1</AssemblyVersion>
-    <FileVersion>2.7.1</FileVersion>
-    <Version>2.7.1</Version>
+    <AssemblyVersion>2.7.2</AssemblyVersion>
+    <FileVersion>2.7.2</FileVersion>
+    <Version>2.7.2</Version>
     <Product>Megrez</Product>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Megrez/src/1_Compositor.cs
+++ b/Megrez/src/1_Compositor.cs
@@ -446,7 +446,8 @@ public partial struct Compositor {
     foreach (int position in range) {
       foreach (int theLength in new BRange(1, Math.Min(MaxSpanLength, range.Upperbound - position) + 1)) {
         List<string> joinedKeyArray = GetJoinedKeyArray(new(position, position + theLength));
-        Node? theNode = GetNodeAt(position, theLength, joinedKeyArray);
+        BRange safeLocationRange = new BRange(0, Spans.Count);
+        Node? theNode = safeLocationRange.Contains(position) ? GetNodeAt(position, theLength, joinedKeyArray) : null;
         if (theNode is {}) {
           if (!updateExisting) continue;
           List<Unigram> unigramsA = TheLangModel.UnigramsFor(joinedKeyArray);


### PR DESCRIPTION
This stops an array-out-of-bounds error.