### PR TITLE
 Turn KeyValuePaired and Unigram into Structs again.

### DIFF
--- a/Megrez.Tests/LMDataForTests.cs
+++ b/Megrez.Tests/LMDataForTests.cs
@@ -30,7 +30,7 @@ public class SimpleLM : LangModelProtocol {
         key = col0;
         value = col1;
       }
-      Unigram u = new(value) { Score = col2 };
+      Unigram u = new(value, col2);
       if (!_database.ContainsKey(key)) _database.Add(key, new());
       _database[key].Add(u);
     });

--- a/Megrez.Tests/Megrez.Tests.csproj
+++ b/Megrez.Tests/Megrez.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>2.7.2</ReleaseVersion>
+    <ReleaseVersion>2.7.3</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Megrez.sln
+++ b/Megrez.sln
@@ -52,6 +52,6 @@ Global
 		$0.DotNetNamingPolicy = $4
 		$4.DirectoryNamespaceAssociation = PrefixedHierarchical
 		$0.StandardHeader = $5
-		version = 2.7.2
+		version = 2.7.3
 	EndGlobalSection
 EndGlobal

--- a/Megrez/Megrez.csproj
+++ b/Megrez/Megrez.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <ReleaseVersion>2.7.2</ReleaseVersion>
+    <ReleaseVersion>2.7.3</ReleaseVersion>
     <PackageId>vChewing.Megrez</PackageId>
     <Authors>Shiki Suen</Authors>
     <Company>Atelier Inmu</Company>
     <Copyright>(c) 2022 and onwards The vChewing Project for Megrez-specific changes; (c) 2022 and onwards Lukhnos Liu for upstream contents.</Copyright>
     <RepositoryUrl>https://github.com/ShikiSuen/MegrezNT</RepositoryUrl>
     <NeutralLanguage>zh-TW</NeutralLanguage>
-    <AssemblyVersion>2.7.2</AssemblyVersion>
-    <FileVersion>2.7.2</FileVersion>
-    <Version>2.7.2</Version>
+    <AssemblyVersion>2.7.3</AssemblyVersion>
+    <FileVersion>2.7.3</FileVersion>
+    <Version>2.7.3</Version>
     <Product>Megrez</Product>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Megrez/src/3_KeyValuePaired.cs
+++ b/Megrez/src/3_KeyValuePaired.cs
@@ -11,11 +11,21 @@ namespace Megrez {
 /// <summary>
 /// 鍵值配對，乃索引鍵陣列與讀音的配對單元。
 /// </summary>
-public class KeyValuePaired : Unigram {
+public class KeyValuePaired {
   /// <summary>
   /// 索引鍵陣列。一般情況下用來放置讀音等可以用來作為索引的內容。
   /// </summary>
   public List<string> KeyArray { get; }
+  /// <summary>
+  /// 資料值，通常是詞語或單個字。
+  /// </summary>
+  /// <value>資料值。</value>
+  public string Value { get; }
+  /// <summary>
+  /// 權重（雙精度小數）。
+  /// </summary>
+  /// <value>權重。</value>
+  public double Score { get; }
   /// <summary>
   /// 初期化一組鍵值配對。
   /// </summary>
@@ -66,7 +76,7 @@ public class KeyValuePaired : Unigram {
   /// 做為預設雜湊函式。
   /// </summary>
   /// <returns>目前物件的雜湊碼。</returns>
-  public override int GetHashCode() => HashCode.Combine(KeyArray, Value);
+  public override int GetHashCode() => HashCode.Combine(KeyArray, Value, Score);
   /// <summary>
   /// 傳回代表目前物件的字串。
   /// </summary>

--- a/Megrez/src/7_Unigram.cs
+++ b/Megrez/src/7_Unigram.cs
@@ -9,17 +9,17 @@ namespace Megrez {
 /// <summary>
 /// 單元圖。
 /// </summary>
-public class Unigram {
+public struct Unigram {
   /// <summary>
   /// 資料值，通常是詞語或單個字。
   /// </summary>
   /// <value>資料值。</value>
-  public string Value { get; set; }
+  public string Value { get; }
   /// <summary>
   /// 權重（雙精度小數）。
   /// </summary>
   /// <value>權重。</value>
-  public double Score { get; set; }
+  public double Score { get; }
   /// <summary>
   /// 初期化一筆「單元圖」。一筆單元圖由一筆資料值與一筆權重數值組成。
   /// </summary>


### PR DESCRIPTION
- Syncing this change from the Swift version of Megres regardless that this might not be a problem in C#.